### PR TITLE
Relational locked context

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -43,6 +43,7 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 /**
@@ -686,7 +687,7 @@ public class RelationalDao<T> implements ShardedDao<T> {
         public <U> LockedContext<T> createOrUpdate(
                 RelationalDao<U> relationalDao,
                 DetachedCriteria criteria,
-                Function<U, U> updater,
+                UnaryOperator<U> updater,
                 Supplier<U> entityGenerator) {
             return apply(parent -> {
                 try {

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -6,7 +6,8 @@
         </encoder>
     </appender>
 
-    <logger name="org.hibernate" level="INFO" />
+    <logger name="org.hibernate" level="DEBUG" />
+    <logger name="org.hibernate.SQL" level="DEBUG"/>
     <logger name="org.hibernate.engine.transaction.internal.TransactionImpl" level="DEBUG" />
     <root level="ALL">
         <appender-ref ref="STDOUT"/>

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
@@ -640,7 +640,6 @@ public class LockTest {
                     return child;
                 }, () -> false);
 
-
         contextUpdate.execute();
 
         // get


### PR DESCRIPTION
This PR is to add LockedContext to RelationalDao where sharedKey will determine the shard and criteria will be used to determine a unique row for locking.