### PR TITLE
Adding Readonlycontext for Relationaldao

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
@@ -224,7 +224,7 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
     public <EntityType, T extends Configuration>
     RelationalDao<EntityType> createRelatedObjectDao(Class<EntityType> clazz) {
         return new RelationalDao<>(this.sessionFactories, clazz,
-                new ShardCalculator<>(this.shardManager, new ConsistentHashBucketIdExtractor<>(this.shardManager)));
+                new ShardCalculator<>(this.shardManager, new ConsistentHashBucketIdExtractor<>(this.shardManager)), this.customDatabaseConfig);
     }
 
 
@@ -234,21 +234,24 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
                 clazz,
                 new ShardCalculator<>(this.shardManager,
                         new ConsistentHashBucketIdExtractor<>(this.shardManager)),
-                cacheManager);
+                cacheManager,
+                this.customDatabaseConfig);
     }
 
 
     public <EntityType, T extends Configuration>
     RelationalDao<EntityType> createRelatedObjectDao(Class<EntityType> clazz,
                                                      BucketIdExtractor<String> bucketIdExtractor) {
-        return new RelationalDao<>(this.sessionFactories, clazz, new ShardCalculator<>(this.shardManager, bucketIdExtractor));
+        return new RelationalDao<>(this.sessionFactories, clazz, new ShardCalculator<>(this.shardManager, bucketIdExtractor),
+                this.customDatabaseConfig);
     }
 
     public <EntityType, T extends Configuration>
     CacheableRelationalDao<EntityType> createRelatedObjectDao(Class<EntityType> clazz,
                                                               BucketIdExtractor<String> bucketIdExtractor,
                                                               RelationalCache<EntityType> cacheManager) {
-        return new CacheableRelationalDao<>(this.sessionFactories, clazz, new ShardCalculator<>(this.shardManager, bucketIdExtractor), cacheManager);
+        return new CacheableRelationalDao<>(this.sessionFactories, clazz, new ShardCalculator<>(this.shardManager, bucketIdExtractor),
+                cacheManager, this.customDatabaseConfig);
     }
 
 

--- a/src/main/java/io/appform/dropwizard/sharding/dao/CacheableRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/CacheableRelationalDao.java
@@ -18,6 +18,7 @@
 package io.appform.dropwizard.sharding.dao;
 
 import io.appform.dropwizard.sharding.caching.RelationalCache;
+import io.appform.dropwizard.sharding.config.CustomDatabaseConfig;
 import io.appform.dropwizard.sharding.utils.ShardCalculator;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.DetachedCriteria;
@@ -34,8 +35,9 @@ public class CacheableRelationalDao<T> extends RelationalDao<T> {
 
     public CacheableRelationalDao(List<SessionFactory> sessionFactories, Class<T> entityClass,
                                   ShardCalculator<String> shardCalculator,
-                                  RelationalCache<T> cache) {
-        super(sessionFactories, entityClass, shardCalculator);
+                                  RelationalCache<T> cache,
+                                  CustomDatabaseConfig customDatabaseConfig) {
+        super(sessionFactories, entityClass, shardCalculator, customDatabaseConfig);
         this.cache = cache;
     }
 

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -307,15 +307,15 @@ public class LookupDao<T> implements ShardedDao<T> {
     public ReadOnlyContext<T> readOnlyExecutor(String id) {
         int shardId = shardCalculator.shardId(id);
         LookupDaoPriv dao = daos.get(shardId);
-        return new ReadOnlyContext<>(shardId,  dao.sessionFactory, key -> dao.getLocked(key, LockMode.NONE),
-                null, id, customDatabaseConfig.isSkipReadOnlyTransaction());
+        return new ReadOnlyContext<>(shardId,  dao.sessionFactory, () -> dao.getLocked(id, LockMode.NONE),
+                null, customDatabaseConfig.isSkipReadOnlyTransaction());
     }
 
     public ReadOnlyContext<T> readOnlyExecutor(String id, Supplier<Boolean> entityPopulator) {
         int shardId = shardCalculator.shardId(id);
         LookupDaoPriv dao = daos.get(shardId);
-        return new ReadOnlyContext<>(shardId, dao.sessionFactory, key -> dao.getLocked(key, LockMode.NONE),
-                entityPopulator, id, customDatabaseConfig.isSkipReadOnlyTransaction());
+        return new ReadOnlyContext<>(shardId, dao.sessionFactory, () -> dao.getLocked(id, LockMode.NONE),
+                entityPopulator, customDatabaseConfig.isSkipReadOnlyTransaction());
     }
 
     public LockedContext<T> saveAndGetExecutor(T entity) {

--- a/src/main/java/io/appform/dropwizard/sharding/dao/ReadOnlyContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/ReadOnlyContext.java
@@ -3,7 +3,6 @@ package io.appform.dropwizard.sharding.dao;
 import com.google.common.collect.Lists;
 import io.appform.dropwizard.sharding.utils.TransactionHandler;
 import lombok.Getter;
-import lombok.val;
 import lombok.var;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.DetachedCriteria;
@@ -19,24 +18,21 @@ import java.util.function.Supplier;
 public class ReadOnlyContext<T> {
     private final int shardId;
     private final SessionFactory sessionFactory;
-    private final Function<String, T> getter;
+    private final Supplier<T> getter;
     private final Supplier<Boolean> entityPopulator;
-    private final String key;
     private final List<Function<T, Void>> operations = Lists.newArrayList();
     private final boolean skipTransaction;
 
     public ReadOnlyContext(
             int shardId,
             SessionFactory sessionFactory,
-            Function<String, T> getter,
+            Supplier<T> getter,
             Supplier<Boolean> entityPopulator,
-            String key,
             boolean skipTxn) {
         this.shardId = shardId;
         this.sessionFactory = sessionFactory;
         this.getter = getter;
         this.entityPopulator = entityPopulator;
-        this.key = key;
         this.skipTransaction = skipTxn;
     }
 
@@ -104,7 +100,7 @@ public class ReadOnlyContext<T> {
         TransactionHandler transactionHandler = new TransactionHandler(sessionFactory, true, this.skipTransaction);
         transactionHandler.beforeStart();
         try {
-            T result = getter.apply(key);
+            T result = getter.get();
             if (null == result) {
                 return null;
             }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -350,6 +350,7 @@ public class RelationalDao<T> implements ShardedDao<T> {
         return new LockedContext<T>(shardId, dao.sessionFactory, dao::save, entity);
     }
 
+    // Expectation : Criteria must return single Row
     public ReadOnlyContext<T> readOnlyExecutor(String parentKey, DetachedCriteria criteria) {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);
@@ -357,6 +358,7 @@ public class RelationalDao<T> implements ShardedDao<T> {
                 null, customDatabaseConfig.isSkipReadOnlyTransaction());
     }
 
+    // Expectation : Criteria must return single Row
     public ReadOnlyContext<T> readOnlyExecutor(String parentKey, DetachedCriteria criteria, Supplier<Boolean> entityPopulator) {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);

--- a/src/test/java/io/appform/dropwizard/sharding/BalancedDbShardingBundleWithMultipleClassPath.java
+++ b/src/test/java/io/appform/dropwizard/sharding/BalancedDbShardingBundleWithMultipleClassPath.java
@@ -18,23 +18,29 @@
 package io.appform.dropwizard.sharding;
 
 import io.appform.dropwizard.sharding.caching.LookupCache;
+import io.appform.dropwizard.sharding.caching.RelationalCache;
 import io.appform.dropwizard.sharding.config.CustomDatabaseConfig;
 import io.appform.dropwizard.sharding.config.ShardedHibernateFactory;
 import io.appform.dropwizard.sharding.dao.LookupDao;
+import io.appform.dropwizard.sharding.dao.RelationalDao;
 import io.appform.dropwizard.sharding.dao.testdata.entities.TestEntity;
 import io.appform.dropwizard.sharding.dao.testdata.multi.MultiPackageTestEntity;
 import io.appform.dropwizard.sharding.sharding.impl.ConsistentHashBucketIdExtractor;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Restrictions;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class BalancedDbShardingBundleWithMultipleClassPath extends DBShardingBundleTestBase {
 
 
-    public static final LookupCache<TestEntity> CACHE_MANAGER = new LookupCache<TestEntity>() {
+    public static final LookupCache<TestEntity> LOOKUP_CACHE = new LookupCache<TestEntity>() {
 
         private Map<String, TestEntity> cache = new HashMap<>();
 
@@ -51,6 +57,43 @@ public class BalancedDbShardingBundleWithMultipleClassPath extends DBShardingBun
         @Override
         public TestEntity get(String key) {
             return cache.get(key);
+        }
+    };
+    private static final RelationalCache<TestEntity> RELATIONAL_CACHE = new RelationalCache<TestEntity>() {
+        private Map<String, Object> cache = new HashMap<>();
+        @Override
+        public void put(String parentKey, Object key, TestEntity entity) {
+            cache.put(StringUtils.join(parentKey, key, ':'), entity);
+        }
+
+        @Override
+        public void put(String parentKey, List<TestEntity> entities) {
+            cache.put(parentKey, entities);
+        }
+
+        @Override
+        public void put(String parentKey, int first, int numResults, List<TestEntity> entities) {
+            cache.put(StringUtils.join(parentKey, first, numResults,':'), entities);
+        }
+
+        @Override
+        public boolean exists(String parentKey, Object key) {
+            return cache.containsKey(StringUtils.join(parentKey, key, ':'));
+        }
+
+        @Override
+        public TestEntity get(String parentKey, Object key) {
+            return (TestEntity) cache.get(StringUtils.join(parentKey, key,':'));
+        }
+
+        @Override
+        public List<TestEntity> select(String parentKey) {
+            return (List<TestEntity>) cache.get(parentKey);
+        }
+
+        @Override
+        public List<TestEntity> select(String parentKey, int first, int numResults) {
+            return (List<TestEntity>)cache.get(StringUtils.join(parentKey, first, numResults, ':'));
         }
     };
 
@@ -105,7 +148,7 @@ public class BalancedDbShardingBundleWithMultipleClassPath extends DBShardingBun
         Assert.assertEquals(savedTestEntity.get().getText(), fetchedTestEntity.get().getText());
 
         // Cacheble
-        LookupDao<TestEntity> testEntityLookupDaoCacheble = bundle.createParentObjectDao(TestEntity.class, CACHE_MANAGER);
+        LookupDao<TestEntity> testEntityLookupDaoCacheble = bundle.createParentObjectDao(TestEntity.class, LOOKUP_CACHE);
         Optional<TestEntity> savedTestEntityCacheble = testEntityLookupDaoCacheble.save(testEntity);
         Assert.assertEquals(testEntity.getText(), savedTestEntityCacheble.get().getText());
 
@@ -121,11 +164,54 @@ public class BalancedDbShardingBundleWithMultipleClassPath extends DBShardingBun
         Assert.assertEquals(savedEntityLookupDaoBucketizer.get().getText(), fetchEntityLookupDaoBucketizer.get().getText());
 
         // Cacheble + Bucketizer
-        LookupDao<TestEntity> testEntityLookupDaoCachebleAndBucketizer = bundle.createParentObjectDao(TestEntity.class, new ConsistentHashBucketIdExtractor<>(bundle.getShardManager()), CACHE_MANAGER);
+        LookupDao<TestEntity> testEntityLookupDaoCachebleAndBucketizer = bundle.createParentObjectDao(TestEntity.class, new ConsistentHashBucketIdExtractor<>(bundle.getShardManager()), LOOKUP_CACHE);
         Optional<TestEntity> savedEntityLookupDaoCachebleAndBucketizer = testEntityLookupDaoCachebleAndBucketizer.save(testEntity);
         Assert.assertEquals(testEntity.getText(), savedEntityLookupDaoCachebleAndBucketizer.get().getText());
 
         Optional<TestEntity> fetchEntityLookupDaoCachebleAndBucketizer = testEntityLookupDaoCachebleAndBucketizer.get(testEntity.getExternalId());
         Assert.assertEquals(savedEntityLookupDaoCachebleAndBucketizer.get().getText(), fetchEntityLookupDaoCachebleAndBucketizer.get().getText());
+
+        // Relation DAO
+        DetachedCriteria criteria = DetachedCriteria.forClass(TestEntity.class)
+                .add(Restrictions.eq("externalId", testEntity.getExternalId()));
+
+        // Basic
+        RelationalDao<TestEntity> testEntityRelationalDao = bundle.createRelatedObjectDao(TestEntity.class);
+        Optional<TestEntity> savedEntityRelationDao = testEntityRelationalDao.save(testEntity.getExternalId(), testEntity);
+        Assert.assertEquals(testEntity.getText(), savedEntityRelationDao.get().getText());
+
+        List<TestEntity> fetchRelationList = testEntityRelationalDao.select(testEntity.getExternalId(),criteria, 0, Integer.MAX_VALUE);
+        Assert.assertEquals(1, fetchRelationList.size());
+        Assert.assertEquals(savedEntityRelationDao.get().getText(), fetchRelationList.get(0).getText());
+
+        // Cacheble
+        RelationalDao<TestEntity> testEntityRelationalDaoCacheble = bundle.createRelatedObjectDao(TestEntity.class, RELATIONAL_CACHE);
+        Optional<TestEntity> savedEntityRelationDaoCacheble = testEntityRelationalDaoCacheble.save(testEntity.getExternalId(), testEntity);
+        Assert.assertEquals(testEntity.getText(), savedEntityRelationDaoCacheble.get().getText());
+
+        List<TestEntity> fetchRelationListCacheble = testEntityRelationalDaoCacheble.select(testEntity.getExternalId(),criteria, 0, Integer.MAX_VALUE);
+        Assert.assertEquals(1, fetchRelationListCacheble.size());
+        Assert.assertEquals(savedEntityRelationDaoCacheble.get().getText(), fetchRelationListCacheble.get(0).getText());
+
+        // Cacheble
+        RelationalDao<TestEntity> testEntityRelationalDaoBucketizer = bundle.createRelatedObjectDao(TestEntity.class,
+                new ConsistentHashBucketIdExtractor<>(bundle.getShardManager()));
+        Optional<TestEntity> savedEntityRelationDaoBucketizer = testEntityRelationalDaoBucketizer.save(testEntity.getExternalId(), testEntity);
+        Assert.assertEquals(testEntity.getText(), savedEntityRelationDaoBucketizer.get().getText());
+
+        List<TestEntity> fetchRelationListBucketizer = testEntityRelationalDaoBucketizer.select(testEntity.getExternalId(),criteria, 0, Integer.MAX_VALUE);
+        Assert.assertEquals(1, fetchRelationListBucketizer.size());
+        Assert.assertEquals(savedEntityRelationDaoBucketizer.get().getText(), fetchRelationListBucketizer.get(0).getText());
+
+        // Cacheble + Bucketizer
+        RelationalDao<TestEntity> testEntityRelationalDaoCachebleAndBucketizer = bundle.createRelatedObjectDao(TestEntity.class,
+                new ConsistentHashBucketIdExtractor<>(bundle.getShardManager()), RELATIONAL_CACHE);
+        Optional<TestEntity> savedEntityRelationDaoCachebleAndBucketizer = testEntityRelationalDaoCachebleAndBucketizer.save(testEntity.getExternalId(), testEntity);
+        Assert.assertEquals(testEntity.getText(), savedEntityRelationDaoCachebleAndBucketizer.get().getText());
+
+        List<TestEntity> fetchRelationListCachebleAndBucketizer = testEntityRelationalDaoCachebleAndBucketizer.select(testEntity.getExternalId(),criteria, 0, Integer.MAX_VALUE);
+        Assert.assertEquals(1, fetchRelationListCachebleAndBucketizer.size());
+        Assert.assertEquals(savedEntityRelationDaoCachebleAndBucketizer.get().getText(), fetchRelationListCachebleAndBucketizer.get(0).getText());
+
     }
 }

--- a/src/test/java/io/appform/dropwizard/sharding/dao/CacheableLookupDaoTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/CacheableLookupDaoTest.java
@@ -84,6 +84,7 @@ public class CacheableLookupDaoTest {
             sessionFactories.add(buildSessionFactory(String.format("db_%d", i)));
         }
         final ShardManager shardManager = new BalancedShardManager(sessionFactories.size());
+        final CustomDatabaseConfig customDatabaseConfig = new CustomDatabaseConfig();
         lookupDao = new CacheableLookupDao<>(
                 sessionFactories,
                 TestEntity.class,
@@ -107,7 +108,7 @@ public class CacheableLookupDaoTest {
                         return cache.get(key);
                     }
                 },
-                new CustomDatabaseConfig());
+                customDatabaseConfig);
         phoneDao = new CacheableLookupDao<>(sessionFactories,
                                             Phone.class,
                                             new ShardCalculator<>(shardManager,
@@ -131,7 +132,7 @@ public class CacheableLookupDaoTest {
                                                     return cache.get(key);
                                                 }
                                             },
-                new CustomDatabaseConfig());
+                customDatabaseConfig);
         transactionDao = new CacheableRelationalDao<>(sessionFactories,
                                                       Transaction.class,
                                                       new ShardCalculator<>(shardManager,
@@ -198,7 +199,8 @@ public class CacheableLookupDaoTest {
                                                                       numResults,
                                                                       ':'));
                                                           }
-                                                      });
+                                                      },
+                customDatabaseConfig);
         auditDao = new CacheableRelationalDao<>(sessionFactories,
                                                 Audit.class,
                                                 new ShardCalculator<>(shardManager,
@@ -252,7 +254,8 @@ public class CacheableLookupDaoTest {
                                                                                                         numResults,
                                                                                                         ':'));
                                                     }
-                                                });
+                                                },
+                customDatabaseConfig);
     }
 
     @After

--- a/src/test/java/io/appform/dropwizard/sharding/dao/LookupDaoTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/LookupDaoTest.java
@@ -29,6 +29,7 @@ import io.appform.dropwizard.sharding.sharding.BalancedShardManager;
 import io.appform.dropwizard.sharding.sharding.ShardManager;
 import io.appform.dropwizard.sharding.sharding.impl.ConsistentHashBucketIdExtractor;
 import io.appform.dropwizard.sharding.utils.ShardCalculator;
+import lombok.SneakyThrows;
 import lombok.val;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistry;
@@ -90,8 +91,8 @@ public class LookupDaoTest {
         final CustomDatabaseConfig customDatabaseConfig= new CustomDatabaseConfig();
         lookupDao = new LookupDao<>(sessionFactories, TestEntity.class, shardCalculator, customDatabaseConfig);
         phoneDao = new LookupDao<>(sessionFactories, Phone.class, shardCalculator, customDatabaseConfig);
-        transactionDao = new RelationalDao<>(sessionFactories, Transaction.class, shardCalculator);
-        auditDao = new RelationalDao<>(sessionFactories, Audit.class, shardCalculator);
+        transactionDao = new RelationalDao<>(sessionFactories, Transaction.class, shardCalculator, customDatabaseConfig);
+        auditDao = new RelationalDao<>(sessionFactories, Audit.class, shardCalculator, customDatabaseConfig);
     }
 
     @After
@@ -381,6 +382,49 @@ public class LookupDaoTest {
                 1L,
                 (long)lookupDao.count(criteria).stream().reduce(0L, Long::sum)
         );
+
+    }
+
+    @Test
+    @SneakyThrows
+    public void test() {
+        Transaction transaction = Transaction.builder()
+                .transactionId("TXNID")
+                .amount(100)
+                .to("9986402019")
+                .build();
+        Audit started = Audit.builder()
+                .text("Started")
+                .transaction(transaction)
+                .build();
+
+        Audit completed = Audit.builder()
+                .text("Completed")
+                .transaction(transaction)
+                .build();
+
+        transaction.setAudits(ImmutableList.of(started, completed));
+        transactionDao.save(transaction.getTransactionId(), transaction);
+
+
+        val criteria = DetachedCriteria.forClass(Transaction.class)
+                .add(Restrictions.eq("transactionId", transaction.getTransactionId()));
+
+        val auditCriteria = DetachedCriteria.forClass(Audit.class)
+                .add(Restrictions.eq("transaction.transactionId", transaction.getTransactionId()));
+
+
+        val res = transactionDao.select(transaction.getTransactionId(),criteria, 0, Integer.MAX_VALUE);
+        assertEquals(1, res.size());
+
+        val res2 = transactionDao.readOnlyExecutor(transaction.getTransactionId(), criteria)
+                .readAugmentParent(auditDao, auditCriteria, 0, Integer.MAX_VALUE, (parent, children) -> {
+                    children.forEach(e -> System.out.println(e.getText()));
+                    parent.setAudits(children);
+                })
+                .execute();
+        assertTrue(res2.isPresent());
+        assertEquals(2, res2.get().getAudits().size());
 
     }
 }

--- a/src/test/java/io/appform/dropwizard/sharding/dao/LookupDaoTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/LookupDaoTest.java
@@ -387,7 +387,7 @@ public class LookupDaoTest {
 
     @Test
     @SneakyThrows
-    public void test() {
+    public void testRelationalDaoReadOnlyContext() {
         Transaction transaction = Transaction.builder()
                 .transactionId("TXNID")
                 .amount(100)

--- a/src/test/java/io/appform/dropwizard/sharding/dao/RelationalDaoTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/RelationalDaoTest.java
@@ -19,6 +19,7 @@ package io.appform.dropwizard.sharding.dao;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import io.appform.dropwizard.sharding.config.CustomDatabaseConfig;
 import io.appform.dropwizard.sharding.dao.testdata.entities.RelationalEntity;
 import io.appform.dropwizard.sharding.sharding.BalancedShardManager;
 import io.appform.dropwizard.sharding.sharding.ShardManager;
@@ -69,10 +70,11 @@ public class RelationalDaoTest {
             sessionFactories.add(buildSessionFactory(String.format("db_%d", i)));
         }
         final ShardManager shardManager = new BalancedShardManager(sessionFactories.size());
+        final CustomDatabaseConfig customDatabaseConfig = new CustomDatabaseConfig();
         relationalDao = new RelationalDao<>(sessionFactories,
                                             RelationalEntity.class,
                                             new ShardCalculator<>(shardManager,
-                                                                  new ConsistentHashBucketIdExtractor<>(shardManager)));
+                                                                  new ConsistentHashBucketIdExtractor<>(shardManager)), customDatabaseConfig);
     }
 
     @After

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
@@ -92,7 +92,7 @@ public class LockTest {
         final ShardCalculator<String> shardCalculator = new ShardCalculator<>(shardManager, Integer::parseInt);
         final CustomDatabaseConfig customDatabaseConfig = new CustomDatabaseConfig(true);
         lookupDao = new LookupDao<>(sessionFactories, SomeLookupObject.class, shardCalculator, customDatabaseConfig);
-        relationDao = new RelationalDao<>(sessionFactories, SomeOtherObject.class, shardCalculator);
+        relationDao = new RelationalDao<>(sessionFactories, SomeOtherObject.class, shardCalculator, customDatabaseConfig);
     }
 
     @Test


### PR DESCRIPTION
Support of ReadOnlyContext for relational DAO

Expection: Criteria passed for ReadOnlyContxt must return single row