### PR TITLE
Initial MR for JPA Criteria Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.10-2-SNAPSHOT</version>
+    <version>2.1.10-2</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <source>8</source>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <source>8</source>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -58,16 +58,16 @@
         <url>https://travis-ci.org/santanusinha/dropwizard-db-sharding-bundle</url>
     </ciManagement>
 
-<!--    <distributionManagement>-->
-<!--        <snapshotRepository>-->
-<!--            <id>ossrh</id>-->
-<!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
-<!--        </snapshotRepository>-->
-<!--        <repository>-->
-<!--            <id>ossrh</id>-->
-<!--            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
-<!--        </repository>-->
-<!--    </distributionManagement>-->
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -288,17 +288,17 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.sonatype.plugins</groupId>-->
-<!--                <artifactId>nexus-staging-maven-plugin</artifactId>-->
-<!--                <version>1.6.7</version>-->
-<!--                <extensions>true</extensions>-->
-<!--                <configuration>-->
-<!--                    <serverId>ossrh</serverId>-->
-<!--                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
-<!--                    <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -313,26 +313,26 @@
             </activation>
             <build>
                 <plugins>
-<!--                    <plugin>-->
-<!--                        <groupId>org.apache.maven.plugins</groupId>-->
-<!--                        <artifactId>maven-gpg-plugin</artifactId>-->
-<!--                        <version>1.6</version>-->
-<!--                        <executions>-->
-<!--                            <execution>-->
-<!--                                <id>sign-artifacts</id>-->
-<!--                                <phase>verify</phase>-->
-<!--                                <goals>-->
-<!--                                    <goal>sign</goal>-->
-<!--                                </goals>-->
-<!--                                <configuration>-->
-<!--                                    <useAgent>true</useAgent>-->
-<!--                                    <executable>gpg2</executable>-->
-<!--                                    &lt;!&ndash; Run something like 'gpg2 -ab out' to cache the creds-->
-<!--                                     on agent before running if needed &ndash;&gt;-->
-<!--                                </configuration>-->
-<!--                            </execution>-->
-<!--                        </executions>-->
-<!--                    </plugin>-->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <useAgent>true</useAgent>
+                                    <executable>gpg2</executable>
+                                    <!-- Run something like 'gpg2 -ab out' to cache the creds
+                                     on agent before running if needed -->
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -58,16 +58,16 @@
         <url>https://travis-ci.org/santanusinha/dropwizard-db-sharding-bundle</url>
     </ciManagement>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+<!--    <distributionManagement>-->
+<!--        <snapshotRepository>-->
+<!--            <id>ossrh</id>-->
+<!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+<!--        </snapshotRepository>-->
+<!--        <repository>-->
+<!--            <id>ossrh</id>-->
+<!--            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>-->
+<!--        </repository>-->
+<!--    </distributionManagement>-->
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -283,17 +283,17 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.sonatype.plugins</groupId>-->
+<!--                <artifactId>nexus-staging-maven-plugin</artifactId>-->
+<!--                <version>1.6.7</version>-->
+<!--                <extensions>true</extensions>-->
+<!--                <configuration>-->
+<!--                    <serverId>ossrh</serverId>-->
+<!--                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
+<!--                    <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 
@@ -308,26 +308,26 @@
             </activation>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <useAgent>true</useAgent>
-                                    <executable>gpg2</executable>
-                                    <!-- Run something like 'gpg2 -ab out' to cache the creds
-                                     on agent before running if needed -->
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
+<!--                    <plugin>-->
+<!--                        <groupId>org.apache.maven.plugins</groupId>-->
+<!--                        <artifactId>maven-gpg-plugin</artifactId>-->
+<!--                        <version>1.6</version>-->
+<!--                        <executions>-->
+<!--                            <execution>-->
+<!--                                <id>sign-artifacts</id>-->
+<!--                                <phase>verify</phase>-->
+<!--                                <goals>-->
+<!--                                    <goal>sign</goal>-->
+<!--                                </goals>-->
+<!--                                <configuration>-->
+<!--                                    <useAgent>true</useAgent>-->
+<!--                                    <executable>gpg2</executable>-->
+<!--                                    &lt;!&ndash; Run something like 'gpg2 -ab out' to cache the creds-->
+<!--                                     on agent before running if needed &ndash;&gt;-->
+<!--                                </configuration>-->
+<!--                            </execution>-->
+<!--                        </executions>-->
+<!--                    </plugin>-->
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.0.28-8</version>
+    <version>2.0.28-9-SNAPSHOT</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>
@@ -126,11 +126,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-hibernate</artifactId>
             <version>${dropwizard.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-            <version>5.6.15.Final</version>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.6.15.Final</version>
+        </dependency>
+        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
             <version>${cglib.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -283,17 +283,17 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.sonatype.plugins</groupId>-->
+<!--                <artifactId>nexus-staging-maven-plugin</artifactId>-->
+<!--                <version>1.6.7</version>-->
+<!--                <extensions>true</extensions>-->
+<!--                <configuration>-->
+<!--                    <serverId>ossrh</serverId>-->
+<!--                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
+<!--                    <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -283,17 +283,17 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.sonatype.plugins</groupId>-->
-<!--                <artifactId>nexus-staging-maven-plugin</artifactId>-->
-<!--                <version>1.6.7</version>-->
-<!--                <extensions>true</extensions>-->
-<!--                <configuration>-->
-<!--                    <serverId>ossrh</serverId>-->
-<!--                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>-->
-<!--                    <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
@@ -379,7 +379,7 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
         //Observer chain starts with filters and ends with listener invocations
         //Terminal observer calls the actual method
         rootObserver = new ListenerTriggeringObserver(new TerminalTransactionObserver()).addListeners(listeners);
-        for (TransactionObserver observer : observers) {
+        for (var observer : observers) {
             if (null == observer) {
                 return;
             }

--- a/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
@@ -60,7 +60,6 @@ import io.dropwizard.setup.Environment;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import lombok.var;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.SessionFactory;
 import org.reflections.Reflections;
@@ -380,7 +379,7 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
         //Observer chain starts with filters and ends with listener invocations
         //Terminal observer calls the actual method
         rootObserver = new ListenerTriggeringObserver(new TerminalTransactionObserver()).addListeners(listeners);
-        for (var observer : observers) {
+        for (TransactionObserver observer : observers) {
             if (null == observer) {
                 return;
             }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/CacheableLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/CacheableLookupDao.java
@@ -44,6 +44,20 @@ public class CacheableLookupDao<T> extends LookupDao<T> {
 
     private LookupCache<T> cache;
 
+    /**
+     * Constructs a CacheableLookupDao instance with caching support.
+     *
+     * This constructor initializes a CacheableLookupDao instance with the provided parameters, enabling caching for
+     * improved performance and data retrieval optimization.
+     *
+     * @param sessionFactories A list of SessionFactory instances for database access.
+     * @param entityClass The Class representing the entity type handled by the DAO.
+     * @param shardCalculator A ShardCalculator for determining the database shard based on keys.
+     * @param cache The LookupCache implementation for caching entities.
+     * @param shardingOptions ShardingBundleOptions for configuring sharding behavior.
+     * @param shardInfoProvider The ShardInfoProvider for obtaining shard information.
+     * @param observer A TransactionObserver for observing transaction events.
+     */
     public CacheableLookupDao(List<SessionFactory> sessionFactories,
                               Class<T> entityClass,
                               ShardCalculator<String> shardCalculator,
@@ -56,14 +70,17 @@ public class CacheableLookupDao<T> extends LookupDao<T> {
     }
 
     /**
-     * Read through an object on the basis of key (value of field annotated with {@link LookupKey}) from cache.
-     * Cache miss will be delegated to {@link LookupDao#get(String)} method.
-     * <b>Note:</b> Lazy loading will not work once the object is returned.
-     * If you need lazy loading functionality use the alternate {@link LookupDao#get(String, Function)} method.
+     * Retrieves an entity from the cache or the database based on the specified key and caches it if necessary.
      *
-     * @param key The value of the key field to look for.
-     * @return The entity
-     * @throws Exception if backing dao throws
+     * This method first checks if the entity exists in the cache based on the provided key. If the entity is found
+     * in the cache, it is returned as an Optional. If not found in the cache, the method falls back to the superclass's
+     * `get` method to retrieve the entity from the database using the specified key. If the entity is found in the database,
+     * it is added to the cache for future access and returned as an Optional. If the entity is not found in either the
+     * cache or the database, an empty Optional is returned.
+     *
+     * @param key The key or identifier of the entity to retrieve.
+     * @return An Optional containing the retrieved entity if found, or an empty Optional if the entity is not found.
+     * @throws Exception If an error occurs during the retrieval process.
      */
     @Override
     public Optional<T> get(String key) throws Exception {
@@ -78,12 +95,16 @@ public class CacheableLookupDao<T> extends LookupDao<T> {
     }
 
     /**
-     * Write through the entity on proper shard based on hash of the value in the key field in the object and into cache.
-     * <b>Note:</b> Lazy loading will not work on the augmented entity.
+     * Saves an entity to the database and caches the saved entity if successful.
      *
-     * @param entity Entity to save
-     * @return Entity
-     * @throws Exception if backing dao throws
+     * This method attempts to save the provided entity to the database using the superclass's `save` method.
+     * If the save operation succeeds, it retrieves the saved entity from the database, caches it, and returns it
+     * wrapped in an Optional. If the save operation fails, it returns an empty Optional.
+     *
+     * @param entity The entity to be saved.
+     * @return An Optional containing the saved entity if the save operation is successful, or an empty Optional
+     *         if the save operation fails.
+     * @throws Exception If an error occurs during the save operation.
      */
     @Override
     public Optional<T> save(T entity) throws Exception {
@@ -96,11 +117,16 @@ public class CacheableLookupDao<T> extends LookupDao<T> {
     }
 
     /**
-     * Update the entity with a given id and refresh the object in the cache.
-     * Actual save will be delegated to {@link LookupDao#update(String, Function)} method.
+     * Updates an entity using the provided updater function and caches the updated entity.
      *
-     * @param id Id of the entity that will be updated
-     * @return True/False
+     * This method updates an entity identified by the given ID using the provided updater function. It first attempts
+     * to update the entity using the superclass's `update` method. If the update operation succeeds, it retrieves the
+     * updated entity from the database, caches it, and returns `true`. If the update operation fails, it returns `false`.
+     *
+     * @param id The ID of the entity to update.
+     * @param updater A function that takes an Optional of the current entity and returns the updated entity.
+     * @return `true` if the entity is successfully updated and cached, or `false` if the update operation fails.
+     * @throws DaoFwdException If an error occurs while updating or caching the entity.
      */
     @Override
     public boolean update(String id, Function<Optional<T>, T> updater) {

--- a/src/main/java/io/appform/dropwizard/sharding/dao/CacheableRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/CacheableRelationalDao.java
@@ -34,6 +34,24 @@ public class CacheableRelationalDao<T> extends RelationalDao<T> {
 
     private RelationalCache<T> cache;
 
+
+    /**
+     * Constructs a CacheableRelationalDao instance for managing entities across multiple shards with caching support.
+     *
+     * This constructor initializes a CacheableRelationalDao instance, which extends the functionality of a
+     * RelationalDao, for working with entities of the specified class distributed across multiple shards.
+     * It requires a list of session factories, a shard calculator, a relational cache, a shard information provider,
+     * and a transaction observer. The entity class should designate one field as the primary key using the `@Id` annotation.
+     *
+     * @param sessionFactories A list of SessionFactory instances for database access across shards.
+     * @param entityClass The Class representing the type of entities managed by this CacheableRelationalDao.
+     * @param shardCalculator A ShardCalculator instance used to determine the shard for each operation.
+     * @param cache A RelationalCache instance for caching entity data.
+     * @param shardInfoProvider A ShardInfoProvider for retrieving shard information.
+     * @param observer A TransactionObserver for monitoring transaction events.
+     * @throws IllegalArgumentException If the entity class does not have exactly one field designated as @Id,
+     *         if the designated key field is not accessible, or if it is not of type String.
+     */
     public CacheableRelationalDao(List<SessionFactory> sessionFactories, Class<T> entityClass,
                                   ShardCalculator<String> shardCalculator,
                                   RelationalCache<T> cache,
@@ -43,6 +61,21 @@ public class CacheableRelationalDao<T> extends RelationalDao<T> {
         this.cache = cache;
     }
 
+
+    /**
+     * Retrieves an entity from the cache or the database based on the parent key and entity key.
+     *
+     * This method attempts to retrieve an entity from the cache first using the provided parent key and entity key.
+     * If the entity is found in the cache, it is returned as an Optional. If not found in the cache, the method falls
+     * back to the parent class's (superclass) `get` method to retrieve the entity from the database. If the entity is
+     * found in the database, it is added to the cache for future access. If the entity is not found in either the cache
+     * or the database, an empty Optional is returned.
+     *
+     * @param parentKey The parent key associated with the entity.
+     * @param key The key of the entity to retrieve.
+     * @return An Optional containing the retrieved entity if found, or an empty Optional if the entity is not found.
+     * @throws IllegalArgumentException If the parent key or entity key is invalid.
+     */
     @Override
     public Optional<T> get(String parentKey, Object key) {
         if (cache.exists(parentKey, key)) {

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
@@ -140,6 +140,13 @@ public class LockedContext<T> {
         });
     }
 
+    /**
+     * Queries using the specified criteria across all shards and returns the counts of rows satisfying the criteria.
+     * <b>Note:</b> This method runs the query serially and it's usage is not recommended.
+     *
+     * @param criteria The select criteria
+     * @return List of counts in each shard
+     */
     @Deprecated
     public <U> LockedContext<T> createOrUpdate(
             RelationalDao<U> relationalDao,

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
@@ -16,6 +16,13 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+/**
+ * The `LockedContext` class encapsulates the context for locked operations on an entity in a specific shard.
+ * It provides various methods for applying operations and actions to the entity within the context of a transaction.
+ * This context can be used for both reading and inserting entities.
+ *
+ * @param <T> The type of the entity on which the operations are performed.
+ */
 @Getter
 public class LockedContext<T> {
     @FunctionalInterface
@@ -67,6 +74,14 @@ public class LockedContext<T> {
         this.executionContext = buildExecutionContext(shardInfoProvider, entityClass);
     }
 
+
+    /**
+     * Applies a custom mutator function to the parent entity within this locked context. The mutator function is responsible
+     * for making modifications to the parent entity based on specific business logic.
+     *
+     * @param mutator The mutator function that defines how to modify the parent entity.
+     * @return A reference to this `LockedContext` to allow method chaining.
+     */
     public LockedContext<T> mutate(Mutator<T> mutator) {
         return apply(parent -> {
             mutator.mutator(parent);
@@ -79,6 +94,20 @@ public class LockedContext<T> {
         return this;
     }
 
+    /**
+     * Generates entity of type {@code U} using entityGenerator and then persists them
+     *
+     * @param <U>             The type of the associated entity to be saved.
+     * @param relationalDao   The relational DAO responsible for saving the associated entity.
+     * @param entityGenerator A function that generates the associated entity based on the parent entity.
+     * @return A reference to this LockedContext, enabling method chaining.
+     * @throws RuntimeException         if an exception occurs during entity generation or saving.
+     *                                  This exception typically wraps any underlying exceptions that may occur
+     *                                  during the execution of the entity generation or save operation.
+     *                                  It indicates that the save operation was unsuccessful.
+     * @throws IllegalArgumentException if the provided relational DAO or entity generator function is null.
+     *                                  This exception indicates invalid or missing inputs.
+     */
     public <U> LockedContext<T> save(RelationalDao<U> relationalDao, Function<T, U> entityGenerator) {
         return apply(parent -> {
             try {
@@ -91,6 +120,20 @@ public class LockedContext<T> {
         });
     }
 
+    /**
+     * Generates list of entity of type {@code U} using entityGenerator and then persists them in bulk
+     *
+     * @param <U>             The type of the associated entity to be saved.
+     * @param relationalDao   The relational DAO responsible for saving the associated entity.
+     * @param entityGenerator A function that generates the associated entity based on the parent entity.
+     * @return A reference to this LockedContext, enabling method chaining.
+     * @throws RuntimeException         if an exception occurs during entity generation or saving.
+     *                                  This exception typically wraps any underlying exceptions that may occur
+     *                                  during the execution of the entity generation or save operation.
+     *                                  It indicates that the save operation was unsuccessful.
+     * @throws IllegalArgumentException if the provided relational DAO or entity generator function is null.
+     *                                  This exception indicates invalid or missing inputs.
+     */
     public <U> LockedContext<T> saveAll(RelationalDao<U> relationalDao, Function<T, List<U>> entityGenerator) {
         return apply(parent -> {
             try {
@@ -98,17 +141,6 @@ public class LockedContext<T> {
                 for (U entity : entities) {
                     relationalDao.save(this, entity);
                 }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            return null;
-        });
-    }
-
-    public <U> LockedContext<T> save(RelationalDao<U> relationalDao, U entity, Function<U, U> handler) {
-        return apply(parent -> {
-            try {
-                relationalDao.save(this, entity, handler);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -129,6 +161,62 @@ public class LockedContext<T> {
         });
     }
 
+    /**
+     * Saves an associated entity using a relational DAO, an associated entity instance, and a handler function.
+     *
+     * @param <U>           The type of the associated entity to be saved.
+     * @param relationalDao The relational DAO responsible for saving the associated entity.
+     * @param entity        The associated entity instance to be saved.
+     * @param handler       A handler function that can modify the associated entity before saving.
+     * @return A reference to this LockedContext, enabling method chaining.
+     * @throws RuntimeException         if an exception occurs during the save operation or if the handler function
+     *                                  throws an exception. This exception typically wraps any underlying exceptions
+     *                                  that may occur during the execution of the save operation or the handler function.
+     *                                  It indicates that the save operation was unsuccessful.
+     * @throws IllegalArgumentException if the provided relational DAO or associated entity is null. This exception
+     *                                  indicates invalid or missing inputs.
+     * @implSpec This method allows you to save an associated entity (of type U) using a specified relational DAO,
+     * an associated entity instance, and an optional handler function. The handler function can be used
+     * to modify the associated entity before it is saved.
+     * @apiNote The {@code handler} function, if provided, takes the associated entity (of type U) as input and can
+     * apply custom modifications to it before the save operation. The save operation is performed by
+     * the provided {@code relationalDao}. If the save operation is successful, this method returns a
+     * reference to the current LockedContext, allowing for method chaining. If an exception occurs during
+     * the save operation or if the handler function throws an exception, it is wrapped in a RuntimeException,
+     * indicating that the save operation was unsuccessful.
+     */
+    public <U> LockedContext<T> save(RelationalDao<U> relationalDao, U entity, Function<U, U> handler) {
+        return apply(parent -> {
+            try {
+                relationalDao.save(this, entity, handler);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Updates an associated entity using a relational DAO, an identifier, and a handler function.
+     *
+     * @param <U>           The type of the associated entity to be updated.
+     * @param relationalDao The relational DAO responsible for updating the associated entity.
+     * @param id            The identifier of the associated entity to be updated.
+     * @param handler       A handler function that can modify the associated entity before updating.
+     * @return A reference to this LockedContext, enabling method chaining.
+     * @throws RuntimeException         if an exception occurs during the update operation or if the handler function
+     *                                  throws an exception. This exception typically wraps any underlying exceptions
+     *                                  that may occur during the execution of the update operation or the handler function.
+     *                                  It indicates that the update operation was unsuccessful.
+     * @throws IllegalArgumentException if the provided relational DAO or identifier is null. This exception
+     *                                  indicates invalid or missing inputs.
+     * @apiNote The {@code handler} function, if provided, takes the associated entity (of type U) as input and can
+     * apply custom modifications to it before the update operation. The update operation is performed by
+     * the provided {@code relationalDao}. If the update operation is successful, this method returns a
+     * reference to the current LockedContext, allowing for method chaining. If an exception occurs during
+     * the update operation or if the handler function throws an exception, it is wrapped in a RuntimeException,
+     * indicating that the update operation was unsuccessful.
+     */
     public <U> LockedContext<T> update(RelationalDao<U> relationalDao, Object id, Function<U, U> handler) {
         return apply(parent -> {
             try {
@@ -147,7 +235,6 @@ public class LockedContext<T> {
      * @param criteria The select criteria
      * @return List of counts in each shard
      */
-    @Deprecated
     public <U> LockedContext<T> createOrUpdate(
             RelationalDao<U> relationalDao,
             DetachedCriteria criteria,
@@ -163,7 +250,23 @@ public class LockedContext<T> {
         });
     }
 
-
+    /**
+     * Creates or updates using this context using the provided relational data access object (DAO),
+     * query specification, updater function, and entity generator
+     *
+     * @param <U>             The type of entity being operated upon by the DAO, updater, and generator.
+     * @param relationalDao   The relational data access object responsible for performing the create
+     *                        or update operation on the entity.
+     * @param querySpec       The query specification that defines the criteria for locating the entity
+     *                        to be created or updated.
+     * @param updater         A function that specifies how to update the entity if it already exists.
+     *                        It takes an existing entity as input and returns the updated entity.
+     * @param entityGenerator A supplier function that provides a new entity to be created if the entity
+     *                        specified by the query specification does not exist.
+     * @return A LockedContext<T> representing the result of the create or update operation.
+     * @throws RuntimeException If an exception occurs during the create or update operation, it is wrapped
+     *                          in a RuntimeException and thrown.
+     */
     public <U> LockedContext<T> createOrUpdate(
             RelationalDao<U> relationalDao,
             QuerySpec<U, U> querySpec,
@@ -179,7 +282,27 @@ public class LockedContext<T> {
         });
     }
 
-    @Deprecated
+    /**
+     * Updates entities in the context using the provided relational data access object (DAO),
+     * criteria for selecting entities, an updater function, and a boolean supplier for
+     * determining whether to continue updating the next matching entity.
+     *
+     * @param <U>           The type of entity being operated upon by the DAO and updater.
+     * @param relationalDao The relational data access object responsible for performing the update
+     *                      operation on the selected entities.
+     * @param criteria      The criteria that define which entities should be updated. This can be a
+     *                      specification of the conditions that entities must meet to be considered
+     *                      for updating.
+     * @param updater       A function that specifies how to update an entity. It takes an existing
+     *                      entity as input and returns the updated entity.
+     * @param updateNext    A boolean supplier that determines whether to continue updating the next
+     *                      matching entity. If this supplier returns true, the update operation
+     *                      continues to the next matching entity; if it returns false, the operation
+     *                      stops.
+     * @return A LockedContext<T> representing the result of the update operation
+     * @throws RuntimeException If an exception occurs during the update operation, it is wrapped
+     *                          in a RuntimeException and thrown.
+     */
     public <U> LockedContext<T> update(
             RelationalDao<U> relationalDao,
             DetachedCriteria criteria,
@@ -195,7 +318,27 @@ public class LockedContext<T> {
         });
     }
 
-
+    /**
+     * Updates entities in the context using the provided relational data access object (DAO),
+     * query specification for selecting entities, an updater function, and a boolean supplier
+     * for determining whether to continue updating the next matching entity.
+     *
+     * @param <U>           The type of entity being operated upon by the DAO and updater.
+     * @param relationalDao The relational data access object responsible for performing the update
+     *                      operation on the selected entities.
+     * @param criteria      The query specification that defines which entities should be updated.
+     *                      This specification typically includes conditions and filters to select
+     *                      the entities to be updated.
+     * @param updater       A function that specifies how to update an entity. It takes an existing
+     *                      entity as input and returns the updated entity.
+     * @param updateNext    A boolean supplier that determines whether to continue updating the next
+     *                      matching entity. If this supplier returns true, the update operation
+     *                      continues to the next matching entity; if it returns false, the operation
+     *                      stops.
+     * @return A LockedContext<T> representing the result of the update operation.
+     * @throws RuntimeException If an exception occurs during the update operation, it is wrapped
+     *                          in a RuntimeException and thrown.
+     */
     public <U> LockedContext<T> update(
             RelationalDao<U> relationalDao,
             QuerySpec<U, U> criteria,

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
@@ -42,6 +42,20 @@ public class LockedContext<T> {
     private final TransactionExecutionContext executionContext;
     private final TransactionObserver observer;
 
+    /**
+     * Constructs a LockedContext for reading a specific entity within a locked transaction.
+     *
+     * This constructor initializes a LockedContext, which provides a locked environment for reading a specific entity
+     * within a transaction. The LockedContext allows you to retrieve the entity while ensuring that the read operation
+     * is performed atomically and under the protection of the locking mechanism.
+     *
+     * @param shardId The identifier of the shard where the entity is located.
+     * @param sessionFactory The Hibernate SessionFactory associated with the entity.
+     * @param getter A supplier function responsible for retrieving the entity within the locked context.
+     * @param entityClass The Class representing the type of the entity.
+     * @param shardInfoProvider A provider for shard-specific information.
+     * @param observer An observer for monitoring transaction events.
+     */
     public LockedContext(
             int shardId,
             SessionFactory sessionFactory,
@@ -57,6 +71,21 @@ public class LockedContext<T> {
         this.executionContext = buildExecutionContext(shardInfoProvider, entityClass);
     }
 
+    /**
+     * Constructs a LockedContext for performing operations on a specific entity within a locked transaction.
+     *
+     * This constructor initializes a LockedContext, which provides a locked environment for performing operations on a
+     * specific entity within a transaction. The LockedContext allows you to work with the entity while ensuring that
+     * modifications are made atomically and under the protection of the locking mechanism.
+     *
+     * @param shardId The identifier of the shard where the entity is located.
+     * @param sessionFactory The Hibernate SessionFactory associated with the entity.
+     * @param saver A function responsible for saving or updating the entity within the context.
+     * @param entity The entity on which operations will be performed within the locked context.
+     * @param entityClass The Class representing the type of the entity.
+     * @param shardInfoProvider A provider for shard-specific information.
+     * @param observer An observer for monitoring transaction events.
+     */
     public LockedContext(
             int shardId,
             SessionFactory sessionFactory,
@@ -73,14 +102,28 @@ public class LockedContext<T> {
         this.mode = Mode.INSERT;
         this.executionContext = buildExecutionContext(shardInfoProvider, entityClass);
     }
-
-
     /**
-     * Applies a custom mutator function to the parent entity within this locked context. The mutator function is responsible
-     * for making modifications to the parent entity based on specific business logic.
+     * Applies a mutation operation to the current context using a provided mutator.
      *
-     * @param mutator The mutator function that defines how to modify the parent entity.
-     * @return A reference to this `LockedContext` to allow method chaining.
+     * @param <T> The type parameter representing the parent entity.
+     * @param mutator The mutator responsible for applying the mutation operation to the context.
+     * @return A reference to this LockedContext, enabling method chaining.
+     *
+     * <p>
+     * This method allows the application of a mutation operation to the current context using a provided mutator.
+     * The mutator is responsible for specifying the mutation logic to be applied to the context.
+     * </p>
+     *
+     * <p>
+     * The {@code mutator} parameter represents an instance of a {@link Mutator} interface, which defines the
+     * mutation logic to be executed on the context. The {@link Mutator#mutate(LockedContext)} method of the
+     * mutator is invoked, allowing custom mutations to be performed on the context.
+     * </p>
+     *
+     * <p>
+     * After the mutation operation is applied, this method returns a reference to the current LockedContext, enabling
+     * method chaining or further operations on the modified context.
+     * </p>
      */
     public LockedContext<T> mutate(Mutator<T> mutator) {
         return apply(parent -> {
@@ -89,6 +132,17 @@ public class LockedContext<T> {
         });
     }
 
+    /**
+     * Applies a handler function to the current entity within a locked context.
+     *
+     * This method allows you to apply a handler function to the current entity within the context of a locked transaction.
+     * The handler function is provided as a {@code Function}
+     * The handler is added to a list of operations to be executed within the locked context.
+     *
+     * @param <T> The type parameter representing the parent entity.
+     * @param handler The handler function to apply to the current entity.
+     * @return A locked context for the current entity type, allowing for further chained operations within a locked transaction.
+     */
     public LockedContext<T> apply(Function<T, Void> handler) {
         this.operations.add(handler);
         return this;
@@ -148,6 +202,20 @@ public class LockedContext<T> {
         });
     }
 
+    /**
+     * Initiates an update operation using a query against a related RelationalDao within a locked context.
+     *
+     * This method allows you to initiate an update operation using a query against a related {@code RelationalDao} within the
+     * context of a locked transaction. It takes a {@code RelationalDao} instance and an {@code UpdateOperationMeta} object to specify
+     * the details of the update operation. The update operation is executed within the locked context provided by this
+     * method.
+     *
+     * @param <U> The type parameter representing the entity type of the related {@code RelationalDao}.
+     * @param relationalDao The related {@code RelationalDao} used to perform the update operation.
+     * @param updateOperationMeta The {@code UpdateOperationMeta} containing details of the update operation to be executed.
+     * @return A locked context for the current entity type, allowing for further chained operations within a locked transaction.
+     * @throws RuntimeException If an error occurs during the update operation or query execution.
+     */
     public <U> LockedContext<T> updateUsingQuery(
             RelationalDao<U> relationalDao,
             UpdateOperationMeta updateOperationMeta) {
@@ -175,15 +243,6 @@ public class LockedContext<T> {
      *                                  It indicates that the save operation was unsuccessful.
      * @throws IllegalArgumentException if the provided relational DAO or associated entity is null. This exception
      *                                  indicates invalid or missing inputs.
-     * @implSpec This method allows you to save an associated entity (of type U) using a specified relational DAO,
-     * an associated entity instance, and an optional handler function. The handler function can be used
-     * to modify the associated entity before it is saved.
-     * @apiNote The {@code handler} function, if provided, takes the associated entity (of type U) as input and can
-     * apply custom modifications to it before the save operation. The save operation is performed by
-     * the provided {@code relationalDao}. If the save operation is successful, this method returns a
-     * reference to the current LockedContext, allowing for method chaining. If an exception occurs during
-     * the save operation or if the handler function throws an exception, it is wrapped in a RuntimeException,
-     * indicating that the save operation was unsuccessful.
      */
     public <U> LockedContext<T> save(RelationalDao<U> relationalDao, U entity, Function<U, U> handler) {
         return apply(parent -> {
@@ -210,12 +269,23 @@ public class LockedContext<T> {
      *                                  It indicates that the update operation was unsuccessful.
      * @throws IllegalArgumentException if the provided relational DAO or identifier is null. This exception
      *                                  indicates invalid or missing inputs.
-     * @apiNote The {@code handler} function, if provided, takes the associated entity (of type U) as input and can
-     * apply custom modifications to it before the update operation. The update operation is performed by
-     * the provided {@code relationalDao}. If the update operation is successful, this method returns a
-     * reference to the current LockedContext, allowing for method chaining. If an exception occurs during
-     * the update operation or if the handler function throws an exception, it is wrapped in a RuntimeException,
-     * indicating that the update operation was unsuccessful.
+     *
+     * <p>
+     * This method allows for the updating of an associated entity using a provided relational DAO. It requires specifying
+     * the identifier of the entity to be updated and, optionally, a handler function that can apply custom modifications
+     * to the entity before the update operation is performed.
+     * </p>
+     *
+     * <p>
+     * The {@code handler} function, if provided, takes the associated entity (of type U) as input and can be used to
+     * apply custom changes to the entity's state before it is updated using the provided {@code relationalDao}.
+     * </p>
+     *
+     * <p>
+     * If the update operation is successful, this method returns a reference to the current LockedContext, allowing for
+     * method chaining. However, if an exception occurs during the update operation or if the handler function throws an
+     * exception, a {@code RuntimeException} is thrown, indicating that the update operation was unsuccessful.
+     * </p>
      */
     public <U> LockedContext<T> update(RelationalDao<U> relationalDao, Object id, Function<U, U> handler) {
         return apply(parent -> {
@@ -229,11 +299,37 @@ public class LockedContext<T> {
     }
 
     /**
-     * Queries using the specified criteria across all shards and returns the counts of rows satisfying the criteria.
-     * <b>Note:</b> This method runs the query serially and it's usage is not recommended.
+     * Creates or updates an associated entity using a relational DAO, criteria, an updater function, and an entity generator.
      *
-     * @param criteria The select criteria
-     * @return List of counts in each shard
+     * @param <U>           The type of the parent entity associated with LockedContext
+     * @param relationalDao The relational DAO responsible for creating or updating the associated entity.
+     * @param criteria      The criteria used to determine whether to create or update the entity.
+     * @param updater       A function that can modify the associated entity before updating or creating.
+     * @param entityGenerator A supplier function that generates a new entity if needed.
+     * @return A reference to this LockedContext, enabling method chaining.
+     *
+     * <p>
+     * This method allows for the creation or updating of an associated entity using a provided relational DAO, criteria,
+     * an updater function, and an entity generator. The criteria are used to determine whether to create a new entity or
+     * update an existing one.
+     * </p>
+     *
+     * <p>
+     * The {@code relationalDao} parameter represents an instance of a {@link RelationalDao} responsible for the
+     * create or update operation. The {@code criteria} parameter defines the criteria for determining whether to
+     * create or update the entity. The {@code updater} function can modify the associated entity before the create or
+     * update operation is performed, and the {@code entityGenerator} is used to supply a new entity if creation is required.
+     * </p>
+     *
+     * <p>
+     * After the create or update operation is applied, this method returns a reference to the current LockedContext,
+     * enabling method chaining or further operations on the context.
+     * </p>
+     *
+     * <p>
+     * If an exception occurs during the create or update operation, it is wrapped in a {@link RuntimeException},
+     * indicating that the operation was unsuccessful.
+     * </p>
      */
     public <U> LockedContext<T> createOrUpdate(
             RelationalDao<U> relationalDao,
@@ -354,11 +450,34 @@ public class LockedContext<T> {
         });
     }
 
-
+    /**
+     * Filters the current context based on a predicate, throwing an IllegalArgumentException on failure.
+     *
+     * This overloaded version of the filter method allows you to apply a predicate to the current context's parent entity.
+     * If the predicate evaluates to `false`, it throws an IllegalArgumentException with a default message. If the predicate
+     * evaluates to `true`, the context remains unchanged.
+     *
+     * @param predicate The predicate used to filter the context's parent entity.
+     * @return A LockedContext representing the filtered or unchanged context.
+     * @throws IllegalArgumentException If the predicate evaluates to `false`, an IllegalArgumentException is thrown
+     *                                  with a default message.
+     */
     public LockedContext<T> filter(Predicate<T> predicate) {
         return filter(predicate, new IllegalArgumentException("Predicate check failed"));
     }
 
+    /**
+     * Filters the current context based on a predicate, throwing an exception on failure.
+     *
+     * This method allows you to apply a predicate to the current context's parent entity. If the predicate
+     * evaluates to `false`, it throws the specified runtime exception. If the predicate evaluates to `true`,
+     * the context remains unchanged.
+     *
+     * @param predicate The predicate used to filter the context's parent entity.
+     * @param failureException The runtime exception to throw if the predicate evaluates to `false`.
+     * @return A LockedContext representing the filtered or unchanged context.
+     * @throws RuntimeException If the predicate evaluates to `false`, the specified runtime exception is thrown.
+     */
     public LockedContext<T> filter(Predicate<T> predicate, RuntimeException failureException) {
         return apply(parent -> {
             boolean result = predicate.test(parent);
@@ -369,6 +488,17 @@ public class LockedContext<T> {
         });
     }
 
+
+    /**
+     * Executes a series of operations within a transactional context and returns a result.
+     *
+     * This method executes a series of operations within a transactional context. It uses an
+     * observer to manage the execution and provides transactional handling for the operations. The operations
+     * are applied to generate an entity result, and the result is returned.
+     *
+     * @return The result of executing the series of operations within a transactional context.
+     * @throws RuntimeException If an exception occurs during the execution of the operations or transaction handling.
+     */
     public T execute() {
         return observer.execute(executionContext, () -> {
             TransactionHandler transactionHandler = new TransactionHandler(sessionFactory, false);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import io.appform.dropwizard.sharding.ShardInfoProvider;
 import io.appform.dropwizard.sharding.execution.TransactionExecutionContext;
 import io.appform.dropwizard.sharding.observers.TransactionObserver;
+import io.appform.dropwizard.sharding.query.QuerySpec;
 import io.appform.dropwizard.sharding.utils.TransactionHandler;
 import lombok.Getter;
 import org.hibernate.SessionFactory;
@@ -139,6 +140,7 @@ public class LockedContext<T> {
         });
     }
 
+    @Deprecated
     public <U> LockedContext<T> createOrUpdate(
             RelationalDao<U> relationalDao,
             DetachedCriteria criteria,
@@ -147,6 +149,22 @@ public class LockedContext<T> {
         return apply(parent -> {
             try {
                 relationalDao.createOrUpdate(this, criteria, updater, entityGenerator);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        });
+    }
+
+
+    public <U> LockedContext<T> createOrUpdate(
+            RelationalDao<U> relationalDao,
+            QuerySpec<U, U> querySpec,
+            Function<U, U> updater,
+            Supplier<U> entityGenerator) {
+        return apply(parent -> {
+            try {
+                relationalDao.createOrUpdate(this, querySpec, updater, entityGenerator);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
@@ -172,6 +172,7 @@ public class LockedContext<T> {
         });
     }
 
+    @Deprecated
     public <U> LockedContext<T> update(
             RelationalDao<U> relationalDao,
             DetachedCriteria criteria,
@@ -186,6 +187,23 @@ public class LockedContext<T> {
             return null;
         });
     }
+
+
+    public <U> LockedContext<T> update(
+            RelationalDao<U> relationalDao,
+            QuerySpec<U, U> criteria,
+            Function<U, U> updater,
+            BooleanSupplier updateNext) {
+        return apply(parent -> {
+            try {
+                relationalDao.update(this, criteria, updater, updateNext);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        });
+    }
+
 
     public LockedContext<T> filter(Predicate<T> predicate) {
         return filter(predicate, new IllegalArgumentException("Predicate check failed"));

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -102,7 +102,6 @@ public class LookupDao<T> implements ShardedDao<T> {
          * @return Extracted element or null if not found.
          */
         T getLocked(String lookupKey, LockModeType lockMode) {
-            // TODO Figure out how to set lockMode correctly here
             val session = currentSession();
             CriteriaBuilder builder = session.getCriteriaBuilder();
             CriteriaQuery<T> criteria = builder.createQuery(entityClass);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -923,6 +923,25 @@ public class LookupDao<T> implements ShardedDao<T> {
             });
         }
 
+
+        /**
+         * Reads and augments a parent entity using a relational DAO, applying a filter and consumer function.
+         *
+         * This method reads and potentially augments a parent entity using a provided relational DAO
+         * and query specification within the current context. It applies a filter to the parent entity
+         * and, if the filter condition is met, executes a query to retrieve related child entities.
+         * The retrieved child entities are then passed to a consumer function for further processing.
+         *
+         * @param relationalDao A RelationalDao<U> representing the DAO for retrieving child entities.
+         * @param querySpec A QuerySpec<U, U> specifying the criteria for selecting child entities.
+         * @param first The index of the first result to retrieve (pagination).
+         * @param numResults The number of child entities to retrieve (pagination).
+         * @param consumer A BiConsumer<T, List<U>> for processing the parent entity and its child entities.
+         * @param filter A Predicate<T> for filtering parent entities to decide whether to process them.
+         * @return A ReadOnlyContext<T> representing the current context.
+         * @throws RuntimeException If any exception occurs during the execution of the query or processing
+         *                          of the parent and child entities.
+         */
         public <U> ReadOnlyContext<T> readAugmentParent(
                 RelationalDao<U> relationalDao,
                 QuerySpec<U, U> querySpec,

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -346,7 +346,7 @@ public class LookupDao<T> implements ShardedDao<T> {
         LookupDaoPriv dao = daos.get(shardId);
         return new ReadOnlyContext<>(shardId,
                 dao.sessionFactory,
-                key -> dao.getLocked(key, LockModeType.NONE),
+                key -> dao.getLocked(key, LockMode.NONE),
                 null,
                 id,
                 shardingOptions.isSkipReadOnlyTransaction(),
@@ -358,7 +358,7 @@ public class LookupDao<T> implements ShardedDao<T> {
         LookupDaoPriv dao = daos.get(shardId);
         return new ReadOnlyContext<>(shardId,
                 dao.sessionFactory,
-                key -> dao.getLocked(key, LockModeType.NONE),
+                key -> dao.getLocked(key, LockMode.NONE),
                 entityPopulator,
                 id,
                 shardingOptions.isSkipReadOnlyTransaction(),

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -152,7 +152,7 @@ public class LookupDao<T> implements ShardedDao<T> {
          * Delete an object
          */
         boolean delete(String id) {
-            return Optional.ofNullable(getLocked(id, LockModeType.PESSIMISTIC_WRITE))
+            return Optional.ofNullable(getLocked(id, LockMode.UPGRADE_NOWAIT))
                     .map(object -> {
                         currentSession().delete(object);
                         return true;

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -171,7 +171,6 @@ public class LookupDao<T> implements ShardedDao<T> {
          *
          * @param criteria The selection criteria to be applied to the query.
          * @return A list of matching entities or an empty list if none are found.
-         * @deprecated Use {@link #select(QuerySpec)} for query operations.
          */
         List<T> select(DetachedCriteria criteria) {
             return list(criteria.getExecutableCriteria(currentSession()));

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -33,7 +33,6 @@ import io.dropwizard.hibernate.AbstractDAO;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import lombok.var;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hibernate.Session;
@@ -259,10 +258,20 @@ public class LookupDao<T> implements ShardedDao<T> {
     private final TransactionObserver observer;
 
     /**
-     * Creates a new sharded DAO. The number of managed shards and bucketing is controlled by the {@link ShardManager}.
+     * Constructs a LookupDao instance for querying and managing entities across multiple shards.
      *
-     * @param sessionFactories a session provider for each shard
-     * @param shardCalculator  calculator for shards
+     * This constructor initializes a LookupDao instance for working with entities of the specified class
+     * distributed across multiple shards. It requires a list of session factories, a shard calculator,
+     * sharding options, a shard information provider, and a transaction observer.
+     *
+     * @param sessionFactories A list of SessionFactory instances for database access across shards.
+     * @param entityClass The Class representing the type of entities managed by this LookupDao.
+     * @param shardCalculator A ShardCalculator instance used to determine the shard for each operation.
+     * @param shardingOptions ShardingBundleOptions specifying additional sharding configuration options.
+     * @param shardInfoProvider A ShardInfoProvider for retrieving shard information.
+     * @param observer A TransactionObserver for monitoring transaction events.
+     * @throws IllegalArgumentException If the entity class does not have exactly one field marked as LookupKey,
+     *         if the key field is not accessible, or if it is not of type String.
      */
     public LookupDao(
             List<SessionFactory> sessionFactories,
@@ -697,6 +706,13 @@ public class LookupDao<T> implements ShardedDao<T> {
                 shardId);
     }
 
+    /**
+     * Retrieves the key field associated with the entity class.
+     *
+     * This method returns the Field object representing the key field associated with the entity class.
+     *
+     * @return The Field object representing the key field of the entity class.
+     */
     protected Field getKeyField() {
         return this.keyField;
     }
@@ -887,7 +903,6 @@ public class LookupDao<T> implements ShardedDao<T> {
          * The provided {@code consumer} function is then applied to augment the selected parent entity with related child entities.</p>
          * The filter function selectively applies the consumer function to the chosen parent entity.
          *
-         *
          * @param <U>           The type of child entities.
          * @param relationalDao The relational data access object used to retrieve child entities.
          * @param querySpec     The query specification for selecting parent entities.
@@ -926,18 +941,19 @@ public class LookupDao<T> implements ShardedDao<T> {
 
         /**
          * Reads and augments a parent entity using a relational DAO, applying a filter and consumer function.
-         *
+         * <p>
          * This method reads and potentially augments a parent entity using a provided relational DAO
          * and query specification within the current context. It applies a filter to the parent entity
          * and, if the filter condition is met, executes a query to retrieve related child entities.
-         * The retrieved child entities are then passed to a consumer function for further processing.
+         * The retrieved child entities are then passed to a consumer function for further processing </p>
          *
+         * @param <U> The type of the result expected from the query.
          * @param relationalDao A RelationalDao<U> representing the DAO for retrieving child entities.
-         * @param querySpec A QuerySpec<U, U> specifying the criteria for selecting child entities.
-         * @param first The index of the first result to retrieve (pagination).
-         * @param numResults The number of child entities to retrieve (pagination).
-         * @param consumer A BiConsumer<T, List<U>> for processing the parent entity and its child entities.
-         * @param filter A Predicate<T> for filtering parent entities to decide whether to process them.
+         * @param querySpec     A QuerySpec<U, U> specifying the criteria for selecting child entities.
+         * @param first         The index of the first result to retrieve (pagination).
+         * @param numResults    The number of child entities to retrieve (pagination).
+         * @param consumer      A BiConsumer<T, List<U>> for processing the parent entity and its child entities.
+         * @param filter        A Predicate<T> for filtering parent entities to decide whether to process them.
          * @return A ReadOnlyContext<T> representing the current context.
          * @throws RuntimeException If any exception occurs during the execution of the query or processing
          *                          of the parent and child entities.
@@ -973,7 +989,7 @@ public class LookupDao<T> implements ShardedDao<T> {
          * @return An optional containing the retrieved entity, or an empty optional if not found.
          */
         public Optional<T> execute() {
-            var result = executeImpl();
+            T result = executeImpl();
             if (null == result
                     && null != entityPopulator
                     && Boolean.TRUE.equals(entityPopulator.get())) {//Try to populate entity (maybe from cold store etc)

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -92,7 +92,7 @@ public class LookupDao<T> implements ShardedDao<T> {
         }
 
         T getLockedForWrite(String lookupKey) {
-            return getLocked(lookupKey, LockMode.PESSIMISTIC_WRITE);
+            return getLocked(lookupKey, LockMode.UPGRADE_NOWAIT);
         }
 
         /**

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -43,6 +43,9 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.query.Query;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.List;
@@ -98,10 +101,12 @@ public class LookupDao<T> implements ShardedDao<T> {
          * @return Extracted element or null if not found.
          */
         T getLocked(String lookupKey, LockMode lockMode) {
-            return uniqueResult(currentSession()
-                    .createCriteria(entityClass)
-                    .add(Restrictions.eq(keyField.getName(), lookupKey))
-                    .setLockMode(lockMode));
+            // TODO How to set lockmode here ????
+            CriteriaBuilder criteriaBuilder = currentSession().getCriteriaBuilder();
+            CriteriaQuery<T> query = criteriaBuilder.createQuery(entityClass);
+            Root<T> root = query.from(entityClass);
+            query.where(criteriaBuilder.equal(root.get(keyField.getName()), lookupKey));
+            return uniqueResult(query);
         }
 
         /**

--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -515,6 +515,13 @@ public class RelationalDao<T> implements ShardedDao<T> {
                 entityClass, shardInfoProvider, observer);
     }
 
+
+    /**
+     * Creates a {@code LockedContext} with all the rows matching the {@code QuerySpec}
+     *
+     * @param parentKey       Sharding key to be used for {@code SessionFactory} selection
+     * @param querySpec       QuerySpec to be used. This should contain all JPA filters which need to be applied for row selection
+     */
     public LockedContext<T> lockAndGetExecutor(String parentKey, QuerySpec<T, T> querySpec) {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);
@@ -736,7 +743,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
         return transactionExecutor.execute(dao.sessionFactory, true, dao::select, selectParam, handler, "select", shardId);
     }
 
-    @Deprecated
     public long count(String parentKey, DetachedCriteria criteria) {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);
@@ -748,9 +754,8 @@ public class RelationalDao<T> implements ShardedDao<T> {
      * Returns count of rows matching the selection criteria
      *
      * @param parentKey Sharding key used for sessionFactory selection
-     * @param querySpec QuerySpec to be used. This should contain all JPA filters which need to be applied for row selection
+     * @param querySpec {@link io.appform.dropwizard.sharding.query.QuerySpec} to be used. This should contain all JPA filters which need to be applied for row selection
      */
-
     public long count(String parentKey, QuerySpec<T, Long> querySpec) {
         val shardId = shardCalculator.shardId(parentKey);
         val dao = daos.get(shardId);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -118,7 +118,10 @@ public class RelationalDao<T> implements ShardedDao<T> {
                 criteria.setMaxResults(selectParam.numRows);
                 return list(criteria);
             }
-            return list(QueryUtils.createQuery(currentSession(), entityClass, selectParam.querySpec));
+            val query  = QueryUtils.createQuery(currentSession(), entityClass, selectParam.querySpec);
+            query.setFirstResult(selectParam.start);
+            query.setMaxResults(selectParam.numRows);
+            return list(query);
         }
 
         ScrollableResults scroll(ScrollParamPriv<T> scrollDetails) {
@@ -126,7 +129,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
                 final Criteria criteria = scrollDetails.getCriteria().getExecutableCriteria(currentSession());
                 return criteria.scroll(ScrollMode.FORWARD_ONLY);
             }
-
             return QueryUtils.createQuery(currentSession(), entityClass, scrollDetails.querySpec)
                     .scroll(ScrollMode.FORWARD_ONLY);
         }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -77,20 +77,30 @@ public class RelationalDao<T> implements ShardedDao<T> {
             this.sessionFactory = sessionFactory;
         }
 
-        T get(Object lookupKey) {
-            val criteriaBuilder = currentSession().getCriteriaBuilder();
+//        T get(Object lookupKey) {
+//            return uniqueResult(currentSession()
+//                    .createCriteria(entityClass)
+//                    .add(Restrictions.eq(keyField.getName(), lookupKey))
+//                    .setLockMode(LockMode.READ));
+//        }
+
+        T get(final Object lookupKey) {
+            // TODO Figure out how to set lockmode properly here
+            val session = currentSession();
+            val criteriaBuilder = session.getCriteriaBuilder();
             val query = criteriaBuilder.createQuery(entityClass);
             val root = query.from(entityClass);
             query.where(criteriaBuilder.equal(root.get(keyField.getName()), lookupKey));
-            return uniqueResult(currentSession().createQuery(query).setLockMode(LockModeType.READ));
+            return uniqueResult(query);
         }
 
-        T getLockedForWrite(QuerySpec<T> querySpec) {
+        T getLockedForWrite(final QuerySpec<T> querySpec) {
+            // TODO Figure out how to set lockmode properly here
             val criteriaBuilder = currentSession().getCriteriaBuilder();
             val query = criteriaBuilder.createQuery(entityClass);
             val root = query.from(entityClass);
             querySpec.apply(root, query, criteriaBuilder);
-            return uniqueResult(currentSession().createQuery(query).setLockMode(LockModeType.PESSIMISTIC_WRITE));
+            return uniqueResult(query);
         }
 
         @Deprecated

--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -76,13 +76,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
             this.sessionFactory = sessionFactory;
         }
 
-//        T get(Object lookupKey) {
-//            return uniqueResult(currentSession()
-//                    .createCriteria(entityClass)
-//                    .add(Restrictions.eq(keyField.getName(), lookupKey))
-//                    .setLockMode(LockMode.READ));
-//        }
-
         T get(final Object lookupKey) {
             val session = currentSession();
             val criteriaBuilder = session.getCriteriaBuilder();

--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -75,6 +75,13 @@ public class RelationalDao<T> implements ShardedDao<T> {
             this.sessionFactory = sessionFactory;
         }
 
+
+        /**
+         * Get a row matching the field annotated with {@code @Id} annotation
+         *
+         * @param lookupKey ID for which data needs to be fetched
+         */
+
         T get(final Object lookupKey) {
             val q = createQuery(currentSession(),
                     entityClass,
@@ -83,12 +90,18 @@ public class RelationalDao<T> implements ShardedDao<T> {
             return uniqueResult(q.setLockMode(LockModeType.NONE));
         }
 
+        /**
+         * Reads all rows matching the {@code querySpec} in locked mode. This is equivalent to <i>for update</i> semantics
+         * during database fetch
+         *
+         * @param querySpec QuerySpec to be used. This should contain all JPA filters which need to be applied for row selection
+         */
         T getLockedForWrite(final QuerySpec<T, T> querySpec) {
             val q = createQuery(currentSession(), entityClass, querySpec);
             return uniqueResult(q.setLockMode(LockModeType.PESSIMISTIC_WRITE));
         }
 
-        @Deprecated
+
         T getLockedForWrite(DetachedCriteria criteria) {
             return uniqueResult(criteria.getExecutableCriteria(currentSession())
                     .setLockMode(LockMode.UPGRADE_NOWAIT));
@@ -132,13 +145,17 @@ public class RelationalDao<T> implements ShardedDao<T> {
                     .scroll(ScrollMode.FORWARD_ONLY);
         }
 
-        @Deprecated
+
         long count(final DetachedCriteria criteria) {
             return (long) criteria.getExecutableCriteria(currentSession())
                     .setProjection(Projections.rowCount())
                     .uniqueResult();
         }
 
+        /**
+         * Return count of rows matching the {@code querySpec}
+         * @param querySpec  QuerySpec to be used. This should contain all JPA filters which need to be applied for row selection
+         */
         long count(final QuerySpec<T, Long> querySpec) {
             val session = currentSession();
             CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
@@ -264,7 +281,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
     }
 
 
-    @Deprecated
     <U> boolean update(LockedContext<U> context,
                        DetachedCriteria criteria,
                        Function<T, T> updater,
@@ -346,7 +362,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
     }
 
 
-    @Deprecated
     <U> List<T> select(LookupDao.ReadOnlyContext<U> context, DetachedCriteria criteria, int start, int numResults) throws Exception {
         final RelationalDaoPriv dao = daos.get(context.getShardId());
         SelectParamPriv<T> selectParam = SelectParamPriv.<T>builder()
@@ -413,7 +428,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
 
      */
 
-    @Deprecated
     public boolean update(String parentKey, DetachedCriteria criteria, Function<T, T> updater) {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);
@@ -494,7 +508,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
                 "updateUsingQuery", lockedContext.getShardId());
     }
 
-    @Deprecated
     public LockedContext<T> lockAndGetExecutor(String parentKey, DetachedCriteria criteria) {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);
@@ -517,7 +530,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
                 entityClass, shardInfoProvider, observer);
     }
 
-    @Deprecated
     <U> boolean createOrUpdate(LockedContext<U> context,
                                DetachedCriteria criteria,
                                Function<T, T> updater,
@@ -605,7 +617,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
     }
 
 
-    @Deprecated
     public boolean updateAll(String parentKey, int start, int numRows, DetachedCriteria criteria, Function<T, T> updater) {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);
@@ -676,8 +687,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
         }
     }
 
-
-    @Deprecated
     public List<T> select(String parentKey, DetachedCriteria criteria, int start, int numResults) throws Exception {
         return select(parentKey, criteria, start, numResults, t -> t);
     }
@@ -695,8 +704,6 @@ public class RelationalDao<T> implements ShardedDao<T> {
         return select(parentKey, querySpec, start, numResults, t -> t);
     }
 
-
-    @Deprecated
     public <U> U select(String parentKey, DetachedCriteria criteria, int start, int numResults, Function<List<T>, U> handler) throws Exception {
         int shardId = shardCalculator.shardId(parentKey);
         RelationalDaoPriv dao = daos.get(shardId);

--- a/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
@@ -7,5 +7,4 @@ import javax.persistence.criteria.Root;
 public interface QuerySpec<T, U> {
 
     void apply(Root<T> queryRoot, CriteriaQuery<U> query, CriteriaBuilder criteriaBuilder);
-
 }

--- a/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
@@ -23,16 +23,37 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
+/**
+ * A functional interface representing a query specification.
+ *
+ * @param <T> The type of the entity being queried.
+ * @param <U> The result type of the query specification.
+ *
+ * <p>
+ * The {@code QuerySpec} functional interface defines a contract for applying a query specification to a JPA Criteria
+ * Query. It is typically used to specify filtering and shaping of query results.
+ * </p>
+ *
+ * <p>
+ * Implementations of this interface must provide an {@link #apply(Root, CriteriaQuery, CriteriaBuilder)} method,
+ * which takes a query root, a query, and a criteria builder as parameters. Within this method, developers can specify
+ * various criteria and conditions to be applied to the query.
+ * </p>
+ *
+ * <p>
+ * This interface allows for custom query specifications to be defined and applied to queries, enabling flexibility
+ * in constructing complex database queries.
+ * </p>
+ */
 @FunctionalInterface
 public interface QuerySpec<T, U> {
 
     /**
-     * Applies the query specification to a JPA Criteria query
+     * Applies the query specification to a JPA Criteria Query.
      *
-     * @param queryRoot       The root entity in the query.
-     * @param query           The criteria query to which the specification is applied.
-     * @param criteriaBuilder The criteria builder for building query predicates.
+     * @param queryRoot       The root entity for the query.
+     * @param query           The Criteria Query object to which the specification is applied.
+     * @param criteriaBuilder The CriteriaBuilder for constructing query criteria.
      */
-
     void apply(Root<T> queryRoot, CriteriaQuery<U> query, CriteriaBuilder criteriaBuilder);
 }

--- a/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
@@ -1,0 +1,11 @@
+package io.appform.dropwizard.sharding.query;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+public interface QuerySpec<T> {
+
+    void apply(Root<T> queryRoot, CriteriaQuery<T> query, CriteriaBuilder criteriaBuilder);
+
+}

--- a/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
@@ -4,6 +4,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
+@FunctionalInterface
 public interface QuerySpec<T, U> {
 
     void apply(Root<T> queryRoot, CriteriaQuery<U> query, CriteriaBuilder criteriaBuilder);

--- a/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
@@ -4,8 +4,8 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
-public interface QuerySpec<T> {
+public interface QuerySpec<T, U> {
 
-    void apply(Root<T> queryRoot, CriteriaQuery<T> query, CriteriaBuilder criteriaBuilder);
+    void apply(Root<T> queryRoot, CriteriaQuery<U> query, CriteriaBuilder criteriaBuilder);
 
 }

--- a/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QuerySpec.java
@@ -1,3 +1,22 @@
+/**
+ * The `QuerySpec` interface defines a functional contract for applying query specifications
+ * to a JPA (Java Persistence API) Criteria API query.
+ *
+ * <p>Implementations of this interface can define custom query specifications and apply them
+ * to a JPA Criteria query, typically used for building database queries dynamically.
+ *
+ * @param <T> The type of the entity for which the query specification is applied.
+ * @param <U> The type of the result expected from the query.
+ *
+ * @see javax.persistence.criteria.CriteriaBuilder
+ * @see javax.persistence.criteria.CriteriaQuery
+ * @see javax.persistence.criteria.Root
+ *
+ * @author Your Name
+ * @version 1.0
+ * @since 2023-09-30
+ */
+
 package io.appform.dropwizard.sharding.query;
 
 import javax.persistence.criteria.CriteriaBuilder;
@@ -6,6 +25,14 @@ import javax.persistence.criteria.Root;
 
 @FunctionalInterface
 public interface QuerySpec<T, U> {
+
+    /**
+     * Applies the query specification to a JPA Criteria query
+     *
+     * @param queryRoot       The root entity in the query.
+     * @param query           The criteria query to which the specification is applied.
+     * @param criteriaBuilder The criteria builder for building query predicates.
+     */
 
     void apply(Root<T> queryRoot, CriteriaQuery<U> query, CriteriaBuilder criteriaBuilder);
 }

--- a/src/main/java/io/appform/dropwizard/sharding/query/QueryUtils.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QueryUtils.java
@@ -10,9 +10,32 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.Collection;
 
+/**
+ * A utility class providing common query-related utility methods for constructing predicates in JPA Criteria Queries.
+ *
+ * <p>
+ * The {@code QueryUtils} utility class contains static methods that simplify the creation of predicates
+ * for filtering and querying JPA entities
+ * </p>
+ *
+ * <p>
+ * This class is marked with the {@link lombok.experimental.UtilityClass} annotation, indicating that it should not be instantiated
+ * and is designed for static method access only.
+ * </p>
+ */
 @UtilityClass
 public class QueryUtils {
 
+    /**
+     * Creates a predicate for equality filtering.
+     *
+     * @param <T>            The type of the entity being queried.
+     * @param criteriaBuilder The CriteriaBuilder for constructing query criteria.
+     * @param queryRoot       The root entity for the query.
+     * @param column          The name of the column or attribute to filter on.
+     * @param value           The value to compare for equality.
+     * @return A predicate for equality filtering.
+     */
     public static <T> Predicate equalityFilter(final CriteriaBuilder criteriaBuilder,
                                                final Root<T> queryRoot,
                                                final String column,
@@ -20,6 +43,16 @@ public class QueryUtils {
         return criteriaBuilder.equal(queryRoot.get(column), value);
     }
 
+    /**
+     * Creates a predicate for inequality filtering.
+     *
+     * @param <T>            The type of the entity being queried.
+     * @param criteriaBuilder The CriteriaBuilder for constructing query criteria.
+     * @param queryRoot       The root entity for the query.
+     * @param column          The name of the column or attribute to filter on.
+     * @param value           The value to compare for inequality.
+     * @return A predicate for inequality filtering.
+     */
     public static <T> Predicate notEqualFilter(final CriteriaBuilder criteriaBuilder,
                                                final Root<T> queryRoot,
                                                final String column,
@@ -27,6 +60,15 @@ public class QueryUtils {
         return criteriaBuilder.notEqual(queryRoot.get(column), value);
     }
 
+    /**
+     * Creates a predicate for "in" clause filtering.
+     *
+     * @param <T>     The type of the entity being queried.
+     * @param queryRoot The root entity for the query.
+     * @param column    The name of the column or attribute to filter on.
+     * @param values    A collection of values to check for inclusion in the "in" clause.
+     * @return A predicate for "in" clause filtering.
+     */
     public static <T> Predicate inFilter(final Root<T> queryRoot,
                                          final String column,
                                          final Collection<String> values) {

--- a/src/main/java/io/appform/dropwizard/sharding/query/QueryUtils.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QueryUtils.java
@@ -6,19 +6,30 @@ import org.hibernate.query.Query;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
+import java.util.Collection;
 
 @UtilityClass
 public class QueryUtils {
 
+    public static <T> Predicate equalityFilter(final CriteriaBuilder criteriaBuilder,
+                                               final Root<T> queryRoot,
+                                               final String column,
+                                               final Object value) {
+        return criteriaBuilder.equal(queryRoot.get(column), value);
+    }
 
-    public <T> Query<T> createQuery(final Session session,
-                                    final Class<T> entityClass,
-                                    final QuerySpec<T, T> querySpec) {
-        CriteriaBuilder builder = session.getCriteriaBuilder();
-        CriteriaQuery<T> criteria = builder.createQuery(entityClass);
-        Root<T> root = criteria.from(entityClass);
-        querySpec.apply(root, criteria, builder);
-        return session.createQuery(criteria);
+    public static <T> Predicate notEqualFilter(final CriteriaBuilder criteriaBuilder,
+                                               final Root<T> queryRoot,
+                                               final String column,
+                                               final Object value) {
+        return criteriaBuilder.notEqual(queryRoot.get(column), value);
+    }
+
+    public static <T> Predicate inFilter(final Root<T> queryRoot,
+                                         final String column,
+                                         final Collection<String> values) {
+        return queryRoot.get(column).in(values);
     }
 }

--- a/src/main/java/io/appform/dropwizard/sharding/query/QueryUtils.java
+++ b/src/main/java/io/appform/dropwizard/sharding/query/QueryUtils.java
@@ -1,0 +1,24 @@
+package io.appform.dropwizard.sharding.query;
+
+import lombok.experimental.UtilityClass;
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+
+@UtilityClass
+public class QueryUtils {
+
+
+    public <T> Query<T> createQuery(final Session session,
+                                    final Class<T> entityClass,
+                                    final QuerySpec<T, T> querySpec) {
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaQuery<T> criteria = builder.createQuery(entityClass);
+        Root<T> root = criteria.from(entityClass);
+        querySpec.apply(root, criteria, builder);
+        return session.createQuery(criteria);
+    }
+}

--- a/src/test/java/io/appform/dropwizard/sharding/dao/LookupDaoTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/LookupDaoTest.java
@@ -29,6 +29,7 @@ import io.appform.dropwizard.sharding.dao.testdata.entities.Phone;
 import io.appform.dropwizard.sharding.dao.testdata.entities.TestEntity;
 import io.appform.dropwizard.sharding.dao.testdata.entities.Transaction;
 import io.appform.dropwizard.sharding.observers.internal.ListenerTriggeringObserver;
+import io.appform.dropwizard.sharding.query.QuerySpec;
 import io.appform.dropwizard.sharding.sharding.BalancedShardManager;
 import io.appform.dropwizard.sharding.sharding.ShardManager;
 import io.appform.dropwizard.sharding.sharding.impl.ConsistentHashBucketIdExtractor;
@@ -44,6 +45,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -167,6 +171,25 @@ public class LookupDaoTest {
                 .add(Restrictions.eq("externalId", "testId")));
         assertTrue(results.isEmpty());
 
+        TestEntity testEntity = TestEntity.builder()
+                .externalId("testId")
+                .text("Some Text")
+                .build();
+        lookupDao.save(testEntity);
+        results = lookupDao.scatterGather(DetachedCriteria.forClass(TestEntity.class)
+                .add(Restrictions.eq("externalId", "testId")));
+        assertFalse(results.isEmpty());
+        assertEquals("Some Text",
+                results.get(0)
+                        .getText());
+    }
+
+    @Test
+    public void testScatterGatherWithQuerySpec() throws Exception {
+        List<TestEntity> results = lookupDao
+                .scatterGather((queryRoot, query, criteriaBuilder)
+                        -> query.where(criteriaBuilder.equal(queryRoot.get("externalId"), "testId")));
+        assertTrue(results.isEmpty());
         TestEntity testEntity = TestEntity.builder()
                 .externalId("testId")
                 .text("Some Text")

--- a/src/test/java/io/appform/dropwizard/sharding/dao/RelationalDaoTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/RelationalDaoTest.java
@@ -42,8 +42,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -287,20 +285,6 @@ public class RelationalDaoTest {
     private List<String> generateIdsInSameShard(final int numIdsToBeGenerated) {
         int expectedShardIndex = RandomUtils.nextInt(0, sessionFactories.size());
         return generateIdsInSameShard(expectedShardIndex, numIdsToBeGenerated);
-    }
-
-    private List<List<String>> generateIdsInDifferentShard(int numIdsToBeGenerated) {
-        List<Integer> allowedIndexes = new ArrayList<>();
-        for (int i = 0; i < sessionFactories.size(); i++) {
-            allowedIndexes.add(i);
-        }
-        Collections.shuffle(allowedIndexes);
-        int expectedShardIndexOne = allowedIndexes.get(0);
-        int expectedShardIndexTwo = allowedIndexes.get(1);
-        return Lists.newArrayList(
-                generateIdsInSameShard(expectedShardIndexOne, numIdsToBeGenerated),
-                generateIdsInSameShard(expectedShardIndexTwo, numIdsToBeGenerated)
-        );
     }
 
     private List<String> generateIdsInSameShard(int expectedShardIndex, int numIdsToBeGenerated) {

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
@@ -45,9 +45,6 @@ import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -604,6 +601,49 @@ public class LockTest {
     }
 
     @Test
+    public void testLockingUpdateOneChildWithQuerySpec() throws Exception {
+        SomeOtherObject someOtherObject = SomeOtherObject.builder()
+                .myId("11")
+                .value("Hello")
+                .build();
+
+        SomeOtherObject someOtherObject2 = SomeOtherObject.builder()
+                .myId("12")
+                .value("Hello")
+                .build();
+
+        // save
+        LockedContext<SomeOtherObject> context = relationDao.saveAndGetExecutor(someOtherObject.getMyId(), someOtherObject);
+        context.save(relationDao, parent -> {
+            someOtherObject2.setMyId(String.valueOf(parent.getId()));
+            return someOtherObject2;
+        });
+        context.execute();
+
+        // update
+        LockedContext<SomeOtherObject> contextUpdate = relationDao.lockAndGetExecutor(someOtherObject.getMyId(),
+                (queryRoot, query, criteriaBuilder) ->
+                        query.where(criteriaBuilder.equal(queryRoot.get("myId"), someOtherObject.getMyId())));
+
+        contextUpdate.mutate(parent -> parent.setValue("UPDATE"));
+
+        contextUpdate.update(relationDao, someOtherObject2.getId(),
+                child -> {
+                    child.setValue("HELLO_UPDATED");
+                    return child;
+                });
+
+        contextUpdate.execute();
+
+        // get
+        Optional<SomeOtherObject> resp = relationDao.get(someOtherObject.getMyId(), 1L);
+        assertNotNull(resp.get());
+        Optional<SomeOtherObject> resp1 = relationDao.get(someOtherObject.getMyId(), 2L);
+        assertNotNull(resp1.get());
+        assertEquals("HELLO_UPDATED", resp1.get().getValue());
+    }
+
+    @Test
     public void testLockingUpdateMultipleChild() throws Exception {
         SomeOtherObject someOtherObject = SomeOtherObject.builder()
                 .myId("11")
@@ -708,6 +748,52 @@ public class LockTest {
     }
 
     @Test
+    public void testLockingUpdateOneChildWithCriteriaWithQuerySpec() throws Exception {
+        SomeOtherObject p1 = SomeOtherObject.builder()
+                .myId("11")
+                .value("Hello")
+                .build();
+
+        SomeOtherObject c1 = SomeOtherObject.builder()
+                .myId("12")
+                .value("Hello")
+                .build();
+
+        // save
+        LockedContext<SomeOtherObject> context = relationDao.saveAndGetExecutor(p1.getMyId(), p1);
+        context.save(relationDao, parent -> {
+            c1.setMyId(String.valueOf(parent.getId()));
+            return c1;
+        });
+        context.execute();
+
+        // update
+        LockedContext<SomeOtherObject> contextUpdate = relationDao.lockAndGetExecutor(p1.getMyId(),
+                (queryRoot, query, criteriaBuilder) ->
+                        query.where(criteriaBuilder.equal(queryRoot.get("myId"), p1.getMyId())));
+        contextUpdate.mutate(parent -> parent.setValue("UPDATE"));
+
+        contextUpdate.update(relationDao,
+                DetachedCriteria.forClass(SomeOtherObject.class)
+                        .add(Restrictions.eq("id", c1.getId())),
+                child -> {
+                    child.setValue("CHILD_ONE");
+                    return child;
+                }, () -> false);
+
+        contextUpdate.execute();
+
+        // get
+        Optional<SomeOtherObject> resp = relationDao.get(p1.getMyId(), 1L);
+        assertNotNull(resp.get());
+        assertEquals("UPDATE", resp.get().getValue());
+
+        Optional<SomeOtherObject> resp1 = relationDao.get(p1.getMyId(), 2L);
+        assertNotNull(resp1.get());
+        assertEquals("CHILD_ONE", resp1.get().getValue());
+    }
+
+    @Test
     public void testLockingUpdateMultipleChildWithCriteria() throws Exception {
         SomeOtherObject p1 = SomeOtherObject.builder()
                 .myId("11")
@@ -776,6 +862,75 @@ public class LockTest {
     }
 
     @Test
+    public void testLockingUpdateMultipleChildWithCriteriaWithQuerySpec() throws Exception {
+        SomeOtherObject p1 = SomeOtherObject.builder()
+                .myId("11")
+                .value("Hello")
+                .build();
+
+        SomeOtherObject c1 = SomeOtherObject.builder()
+                .myId("12")
+                .value("Hello")
+                .build();
+
+        SomeOtherObject c2 = SomeOtherObject.builder()
+                .myId("13")
+                .value("Hello")
+                .build();
+
+        // save
+        LockedContext<SomeOtherObject> context = relationDao.saveAndGetExecutor(p1.getMyId(), p1);
+        context.save(relationDao, parent -> {
+            c1.setMyId(String.valueOf(parent.getId()));
+            return c1;
+        });
+        context.save(relationDao, parent -> {
+            c2.setMyId(String.valueOf(parent.getId()));
+            return c2;
+        });
+        context.execute();
+
+        // update
+        LockedContext<SomeOtherObject> contextUpdate = relationDao.lockAndGetExecutor(p1.getMyId(),
+                (queryRoot, query, criteriaBuilder) ->
+                        query.where(criteriaBuilder.equal(queryRoot.get("myId"), p1.getMyId())));
+
+        contextUpdate.mutate(parent -> parent.setValue("UPDATE"));
+
+        contextUpdate.update(relationDao,
+                (queryRoot, query, criteriaBuilder) ->
+                        query.where(criteriaBuilder.equal(queryRoot.get("id"), c1.getId())),
+                child -> {
+                    child.setValue("CHILD_ONE");
+                    return child;
+                }, () -> false);
+
+        contextUpdate.update(relationDao,
+                (queryRoot, query, criteriaBuilder) ->
+                        query.where(criteriaBuilder.equal(queryRoot.get("id"), c2.getId())),
+                child -> {
+                    child.setValue("CHILD_TWO");
+                    return child;
+                }, () -> false);
+
+
+        contextUpdate.execute();
+
+        // get
+        Optional<SomeOtherObject> resp = relationDao.get(p1.getMyId(), 1L);
+        assertNotNull(resp.get());
+        assertEquals("UPDATE", resp.get().getValue());
+
+        Optional<SomeOtherObject> resp1 = relationDao.get(p1.getMyId(), 2L);
+        assertNotNull(resp1.get());
+        assertEquals("CHILD_ONE", resp1.get().getValue());
+
+        Optional<SomeOtherObject> resp2 = relationDao.get(p1.getMyId(), 3L);
+        assertNotNull(resp2.get());
+        assertEquals("CHILD_TWO", resp2.get().getValue());
+    }
+
+    @Test
     @SneakyThrows
     public void testReadMultiChildRetrieve() {
         SomeLookupObject p1 = SomeLookupObject.builder()
@@ -809,6 +964,40 @@ public class LockTest {
 
     @Test
     @SneakyThrows
+    public void testReadMultiChildRetrieveWithQuerySpec() {
+        SomeLookupObject p1 = SomeLookupObject.builder()
+                .myId("0")
+                .name("Parent 1")
+                .build();
+
+        final QuerySpec<SomeOtherObject, SomeOtherObject> querySpec = (queryRoot, query, criteriaBuilder) -> {
+            query.where(
+                    criteriaBuilder.equal(queryRoot.get("myId"), p1.getMyId())
+            );
+            query.orderBy(criteriaBuilder.asc(queryRoot.get("id")));
+        };
+
+        assertFalse(lookupDao.readOnlyExecutor(p1.getMyId()).execute().isPresent());
+
+        val testExecuted = new AtomicBoolean();
+        val res = lookupDao.readOnlyExecutor(p1.getMyId(),
+                        () -> saveEntity(lookupDao.saveAndGetExecutor(p1)))
+                .readAugmentParent(relationDao, querySpec, 0, Integer.MAX_VALUE, (parent, children) -> {
+                    assertNull(parent.getChildren());
+                    assertEquals(6, children.size());
+                    assertNotNull(parent);
+                    testExecuted.set(true);
+                    parent.setChildren(children);
+                })
+                .execute();
+
+        assertTrue(res.isPresent());
+        assertEquals(6, res.get().getChildren().size());
+        assertTrue(testExecuted.get());
+    }
+
+    @Test
+    @SneakyThrows
     public void testReadMultiChildRetrieveNoPopulate() {
         final DetachedCriteria allSelectCriteria = DetachedCriteria.forClass(SomeOtherObject.class)
                 .add(Restrictions.eq("myId", "0"))
@@ -818,6 +1007,27 @@ public class LockTest {
         assertFalse(lookupDao.readOnlyExecutor("0", () -> false)
                 .readAugmentParent(relationDao,
                         allSelectCriteria,
+                        0,
+                        Integer.MAX_VALUE,
+                        (parent, children) -> {
+                        })
+                .execute()
+                .isPresent());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testReadMultiChildRetrieveNoPopulateWithQuerySpec() {
+        final QuerySpec<SomeOtherObject, SomeOtherObject> querySpec = (queryRoot, query, criteriaBuilder) -> {
+            query.where(
+                    criteriaBuilder.equal(queryRoot.get("myId"), "0")
+            );
+            query.orderBy(criteriaBuilder.asc(queryRoot.get("id")));
+        };
+        assertFalse(lookupDao.readOnlyExecutor("0").execute().isPresent());
+        assertFalse(lookupDao.readOnlyExecutor("0", () -> false)
+                .readAugmentParent(relationDao,
+                        querySpec,
                         0,
                         Integer.MAX_VALUE,
                         (parent, children) -> {
@@ -862,6 +1072,54 @@ public class LockTest {
         testExecuted.set(false);
         val res2 = lookupDao.readOnlyExecutor(p2.getMyId())
                 .readAugmentParent(relationDao, allSelectCriteria, 0, Integer.MAX_VALUE, (parent, children) -> {
+                            testExecuted.set(true);
+                        },
+                        p -> !p.getMyId().equals("1")) //Don't read children if object id is blah
+                .execute();
+
+        assertTrue(res2.isPresent());
+        assertFalse(testExecuted.get());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testReadMultiChildConditionalWithQuerySpec() {
+        SomeLookupObject p1 = SomeLookupObject.builder()
+                .myId("0")
+                .name("Parent 1")
+                .build();
+        saveEntity(lookupDao.saveAndGetExecutor(p1));
+        SomeLookupObject p2 = SomeLookupObject.builder()
+                .myId("1")
+                .name("Parent 1")
+                .build();
+        saveEntity(lookupDao.saveAndGetExecutor(p2));
+
+        final QuerySpec<SomeOtherObject, SomeOtherObject> querySpec = (queryRoot, query, criteriaBuilder) -> {
+            query.where(
+                    criteriaBuilder.equal(queryRoot.get("myId"), p1.getMyId())
+            );
+            query.orderBy(criteriaBuilder.asc(queryRoot.get("id")));
+        };
+
+        val testExecuted = new AtomicBoolean();
+        val res = lookupDao.readOnlyExecutor(p1.getMyId())
+                .readAugmentParent(relationDao, querySpec, 0, Integer.MAX_VALUE, (parent, children) -> {
+                    assertNull(parent.getChildren());
+                    assertEquals(6, children.size());
+                    assertNotNull(parent);
+                    testExecuted.set(true);
+                    parent.setChildren(children);
+                })
+                .execute();
+
+        assertTrue(res.isPresent());
+        assertEquals(6, res.get().getChildren().size());
+        assertTrue(testExecuted.get());
+
+        testExecuted.set(false);
+        val res2 = lookupDao.readOnlyExecutor(p2.getMyId())
+                .readAugmentParent(relationDao, querySpec, 0, Integer.MAX_VALUE, (parent, children) -> {
                             testExecuted.set(true);
                         },
                         p -> !p.getMyId().equals("1")) //Don't read children if object id is blah

--- a/src/test/java/io/appform/dropwizard/sharding/dao/testdata/entities/TestEntity.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/testdata/entities/TestEntity.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -31,7 +32,6 @@ import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Entity

--- a/src/test/java/io/appform/dropwizard/sharding/dao/testdata/entities/TestEntity.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/testdata/entities/TestEntity.java
@@ -24,7 +24,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -32,6 +31,7 @@ import javax.persistence.Id;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Entity
@@ -46,6 +46,7 @@ import javax.validation.constraints.NotNull;
         @NamedQuery(name = "testTextUpdateQuery", query = "update TestEntity set text = :text where externalId =:externalId")})
 
 public class TestEntity {
+
     @Id
     @NotNull
     @NotEmpty


### PR DESCRIPTION
This MR takes first stab at supporting JPA Criteria APIs directly instead of relying on Hibernate Criteria API. This MR will serve as a building block for hibernate 6.0 upgrade where Hibernate Criteria API has been removed.

By providing parallel capability of JPA Criteria and Hibernate Criteria, this MR enables a migration path for existing clients without any breaking changes. 

Sequence of events which users of this library need to follow - 

1. Upgrade to the version of library containing both Criteria API support. Version - TBD
2. Make changes to your applications by incrementally reducing reliance on Hibernate Criteria API
3. Over time eliminate application dependency on Hibernate Criteria API completely 
4. Upgrade to a future version of this library which will supports Hibernate 6 (hence Hibernate Criteria API would not be available). Version - TBD