### PR TITLE
Expose get method for entities list

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
@@ -107,7 +107,7 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
 
     private final List<TransactionObserver> observers = new ArrayList<>();
 
-    private final List<Class<?>> entities;
+    private final List<Class<?>> initialisedEntities;
 
     private TransactionObserver rootObserver;
 
@@ -117,18 +117,18 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
             Class<?>... entities) {
         this.dbNamespace = dbNamespace;
         val inEntities = ImmutableList.<Class<?>>builder().add(entity).add(entities).build();
-        this.entities = inEntities;
+        this.initialisedEntities = inEntities;
         init(inEntities);
     }
 
     protected DBShardingBundleBase(String dbNamespace, List<String> classPathPrefixList) {
         this.dbNamespace = dbNamespace;
-        Set<Class<?>> entitiesSet = new Reflections(classPathPrefixList).getTypesAnnotatedWith(Entity.class);
-        Preconditions.checkArgument(!entitiesSet.isEmpty(),
+        Set<Class<?>> entities = new Reflections(classPathPrefixList).getTypesAnnotatedWith(Entity.class);
+        Preconditions.checkArgument(!entities.isEmpty(),
                 String.format("No entity class found at %s",
                         String.join(",", classPathPrefixList)));
-        val inEntities = ImmutableList.<Class<?>>builder().addAll(entitiesSet).build();
-        this.entities = inEntities;
+        val inEntities = ImmutableList.<Class<?>>builder().addAll(entities).build();
+        this.initialisedEntities = inEntities;
         init(inEntities);
     }
 
@@ -140,11 +140,11 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
         this(DEFAULT_NAMESPACE, Arrays.asList(classPathPrefixes));
     }
 
-    public List<Class<?>> getEntities() {
-        if(this.entities == null){
+    public List<Class<?>> getInitialisedEntities() {
+        if(this.initialisedEntities == null){
             throw new RuntimeException("DB sharding bundle is not initialised !");
         }
-        return this.entities;
+        return this.initialisedEntities;
     }
 
     protected abstract ShardManager createShardManager(int numShards, ShardBlacklistingStore blacklistingStore);

--- a/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
@@ -142,8 +142,7 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
 
     public List<Class<?>> getEntities() {
         if(this.entities == null){
-            throw new RuntimeException(
-                    "db sharding bundle is not initialised !");
+            throw new RuntimeException("DB sharding bundle is not initialised !");
         }
         return this.entities;
     }


### PR DESCRIPTION
Context: DB sharing bundle scans all entity class at the time of initialisation and pass it to hibernate bundle. However, it doesn't maintain any entities list at class level.
If any other bundle/class requires the entity list, it again need to scan all classes using reflection which would be redundant.

For instance- in our lease service, we have added a new annotation for few fields in all entity classes. For the new annotation to be scanned, we need to know the list of entities at the startup time. Exposing the get method to access the initialised entities would prevent unnecessary use of reflection.