### PR TITLE
ReadOnlyForRelationalDao Op context made mutable

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lockedcontext/LockAndExecute.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lockedcontext/LockAndExecute.java
@@ -25,9 +25,9 @@ import org.hibernate.Session;
 @Data
 public class LockAndExecute<T> extends OpContext<T> {
 
-    private final List<Consumer<T>> operations = Lists.newArrayList();
+    private List<Consumer<T>> operations = Lists.newArrayList();
     @NonNull
-    private final Mode mode;
+    private Mode mode;
     private Supplier<T> getter;
     private Function<T, T> saver;
     private T entity;

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/relationaldao/readonlycontext/ReadOnlyForRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/relationaldao/readonlycontext/ReadOnlyForRelationalDao.java
@@ -10,7 +10,6 @@ import org.hibernate.Session;
 
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -24,9 +23,9 @@ import java.util.function.Supplier;
 @Builder
 public class ReadOnlyForRelationalDao<T> extends OpContext<List<T>> {
     @NonNull
-    private final Supplier<List<T>> getter;
+    private Supplier<List<T>> getter;
     @Builder.Default
-    private final List<Consumer<List<T>>> operations = Lists.newArrayList();
+    private List<Consumer<List<T>>> operations = Lists.newArrayList();
 
     @Override
     public OpType getOpType() {

--- a/src/test/java/io/appform/dropwizard/sharding/dao/operations/OpContextTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/operations/OpContextTest.java
@@ -1,0 +1,27 @@
+package io.appform.dropwizard.sharding.dao.operations;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reflections.Reflections;
+
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+
+public class OpContextTest {
+
+    /**
+     * Fields in the opcontext implementations should be mutable so that they are available for mutation by observers.
+     */
+    @Test
+    void testFieldsAreMutable() {
+        Reflections reflections = new Reflections("io.appform.dropwizard.sharding.dao.operations");
+        Set<Class<? extends OpContext>> classes = reflections.getSubTypesOf(OpContext.class);
+        classes.stream().forEach(c -> {
+            if (Arrays.stream(c.getDeclaredFields()).anyMatch(field -> Modifier.isFinal(field.getModifiers()))) {
+                Assertions.fail("Immutable field in class " + c.getSimpleName());
+            }
+        });
+
+    }
+}


### PR DESCRIPTION
- ReadOnlyForRelationalDao is made mutable
-  Added test to check mutability of fields in all opcontext impl. So this can be caught in case of any new opcontext addition. 