### PR TITLE
Expose interface for entity registration in DbShardingBundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.10-9</version>
+    <version>2.1.10-10</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>

--- a/src/main/java/io/appform/dropwizard/sharding/BundleCommonBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/BundleCommonBase.java
@@ -2,7 +2,6 @@ package io.appform.dropwizard.sharding;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import io.appform.dropwizard.sharding.config.ShardingBundleOptions;
 import io.appform.dropwizard.sharding.filters.TransactionFilter;
 import io.appform.dropwizard.sharding.listeners.TransactionListener;
@@ -15,6 +14,23 @@ import io.appform.dropwizard.sharding.sharding.ShardBlacklistingStore;
 import io.appform.dropwizard.sharding.sharding.ShardingKey;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import javax.persistence.Entity;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ClassUtils;
 import org.jasypt.encryption.pbe.StandardPBEBigDecimalEncryptor;
@@ -25,45 +41,79 @@ import org.jasypt.hibernate5.encryptor.HibernatePBEEncryptorRegistry;
 import org.jasypt.iv.StringFixedIvGenerator;
 import org.reflections.Reflections;
 
-import javax.persistence.Entity;
-import java.lang.annotation.Annotation;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-
 @Slf4j
 public abstract class BundleCommonBase<T extends Configuration> implements ConfiguredBundle<T> {
 
   protected final List<TransactionListener> listeners = new ArrayList<>();
   protected final List<TransactionFilter> filters = new ArrayList<>();
-
   protected final List<TransactionObserver> observers = new ArrayList<>();
 
-  protected final List<Class<?>> initialisedEntities;
+  protected final List<Class<?>> initialisedEntities = new ArrayList<>();
+  protected final Map<String, EntityMeta> initialisedEntitiesMeta = new HashMap<>();
 
-  protected final Map<String, EntityMeta> initialisedEntitiesMeta = Maps.newHashMap();
+  private final Lock entityInitialisationBlockedLock = new ReentrantLock();
+  private volatile boolean entityInitialisationBlocked = false;
 
   protected TransactionObserver rootObserver;
 
-  protected BundleCommonBase(Class<?> entity, Class<?>... entities) {
-    this.initialisedEntities = ImmutableList.<Class<?>>builder().add(entity).add(entities).build();
-    validateAndBuildEntitiesMeta(initialisedEntities);
+  protected BundleCommonBase(final Class<?> entity, final Class<?>... entities) {
+    initialiseEntitiesAndMeta(ImmutableList.<Class<?>>builder()
+            .add(entity).add(entities).build());
   }
 
-  protected BundleCommonBase(List<String> classPathPrefixList) {
-    Set<Class<?>> entities = new Reflections(classPathPrefixList).getTypesAnnotatedWith(
-        Entity.class);
+  protected BundleCommonBase(final List<String> classPathPrefixList) {
+    final var entities = new Reflections(classPathPrefixList).getTypesAnnotatedWith(Entity.class);
     Preconditions.checkArgument(!entities.isEmpty(),
-        String.format("No entity class found at %s",
-            String.join(",", classPathPrefixList)));
-    this.initialisedEntities = ImmutableList.<Class<?>>builder().addAll(entities).build();
-    validateAndBuildEntitiesMeta(initialisedEntities);
+            String.format("No entity class found at %s", String.join(",", classPathPrefixList)));
+    initialiseEntitiesAndMeta(entities);
+  }
+
+  public final void registerEntities(@NonNull final Class<?>... entities) {
+    entityInitialisationBlockedLock.lock();
+    try {
+      if (entityInitialisationBlocked) {
+        throw new UnsupportedOperationException("Entity registration is not supported after run method execution.");
+      }
+      initialisePendingInitialisationEntitiesAndMeta(Arrays.asList(entities));
+    } finally {
+      entityInitialisationBlockedLock.unlock();
+    }
+  }
+
+  public final void registerEntities(@NonNull final List<String> classPathPrefixList) {
+    entityInitialisationBlockedLock.lock();
+    try {
+      if (entityInitialisationBlocked) {
+        throw new UnsupportedOperationException("Entity registration is not supported after run method execution.");
+      }
+      final var entities = new Reflections(classPathPrefixList).getTypesAnnotatedWith(Entity.class);
+      Preconditions.checkArgument(!entities.isEmpty(),
+              String.format("No entity class found at %s", String.join(",", classPathPrefixList)));
+      initialisePendingInitialisationEntitiesAndMeta(entities);
+    } finally {
+      entityInitialisationBlockedLock.unlock();
+    }
+  }
+
+  private void initialisePendingInitialisationEntitiesAndMeta(final Collection<Class<?>> entities) {
+    final var pendingInitialisationEntities = entities.stream()
+            .filter(entity -> !this.initialisedEntities.contains(entity))
+            .collect(Collectors.toList());
+    initialiseEntitiesAndMeta(pendingInitialisationEntities);
+  }
+
+  private void initialiseEntitiesAndMeta(final Collection<Class<?>> entities) {
+    this.initialisedEntities.addAll(entities);
+    validateAndBuildEntitiesMeta(entities);
+  }
+
+  protected final void blockEntityInitialisation() {
+    entityInitialisationBlockedLock.lock();
+    try {
+      this.entityInitialisationBlocked = true;
+    } finally {
+      entityInitialisationBlockedLock.unlock();
+    }
   }
 
   protected ShardBlacklistingStore getBlacklistingStore() {
@@ -71,10 +121,10 @@ public abstract class BundleCommonBase<T extends Configuration> implements Confi
   }
 
   public List<Class<?>> getInitialisedEntities() {
-    if (this.initialisedEntities == null) {
+    if (this.initialisedEntities.isEmpty()) {
       throw new IllegalStateException("DB sharding bundle is not initialised !");
     }
-    return this.initialisedEntities;
+    return List.copyOf(this.initialisedEntities);
   }
 
   public final void registerObserver(final TransactionObserver observer) {
@@ -166,7 +216,7 @@ public abstract class BundleCommonBase<T extends Configuration> implements Confi
     }
   }
 
-  private void validateAndBuildEntitiesMeta(final List<Class<?>> initialisedEntities) {
+  private void validateAndBuildEntitiesMeta(final Collection<Class<?>> initialisedEntities) {
     initialisedEntities.forEach(clazz -> {
       try {
         final var bucketKeyFieldEntry = fetchAndValidateAnnotateField(clazz, BucketKey.class, Integer.class);

--- a/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/DBShardingBundleBase.java
@@ -39,14 +39,14 @@ import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import org.hibernate.SessionFactory;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.SessionFactory;
 
 /**
  * Base for bundles. This cannot be used by clients. Use one of the derived classes.
@@ -115,6 +115,14 @@ public abstract class DBShardingBundleBase<T extends Configuration> implements C
                 return DBShardingBundleBase.this.getBlacklistingStore();
             }
         };
+    }
+
+    public final void registerEntities(@NonNull final Class<?>... entities) {
+        delegate.registerEntities(entities);
+    }
+
+    public final void registerEntities(@NonNull final List<String> classPathPrefixList) {
+        delegate.registerEntities(classPathPrefixList);
     }
 
     protected ShardBlacklistingStore getBlacklistingStore() {

--- a/src/main/java/io/appform/dropwizard/sharding/MultiTenantDBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/MultiTenantDBShardingBundleBase.java
@@ -55,12 +55,6 @@ import io.dropwizard.Configuration;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
-import org.apache.commons.collections.MapUtils;
-import org.hibernate.SessionFactory;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +67,11 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.apache.commons.collections.MapUtils;
+import org.hibernate.SessionFactory;
 
 /**
  * Base for Multi-Tenant sharding bundles. Clients cannot use this. Use one of the derived classes.
@@ -113,6 +112,7 @@ public abstract class MultiTenantDBShardingBundleBase<T extends Configuration> e
 
   @Override
   public void run(T configuration, Environment environment) {
+    this.blockEntityInitialisation();
     final var tenantedConfig = getConfig(configuration);
     tenantedConfig.getTenants().forEach((tenantId, shardConfig) -> {
       //Encryption Support through jasypt-hibernate5

--- a/src/test/java/io/appform/dropwizard/sharding/DBShardingBundleTestBase.java
+++ b/src/test/java/io/appform/dropwizard/sharding/DBShardingBundleTestBase.java
@@ -17,6 +17,10 @@
 
 package io.appform.dropwizard.sharding;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import io.appform.dropwizard.sharding.dao.RelationalDao;
@@ -26,17 +30,17 @@ import io.appform.dropwizard.sharding.dao.listeners.LoggingListener;
 import io.appform.dropwizard.sharding.dao.testdata.OrderDao;
 import io.appform.dropwizard.sharding.dao.testdata.entities.Order;
 import io.appform.dropwizard.sharding.dao.testdata.entities.OrderItem;
-import org.hibernate.criterion.DetachedCriteria;
-import org.hibernate.criterion.Restrictions;
-import org.junit.jupiter.api.Test;
-
+import io.appform.dropwizard.sharding.dao.testdata.pending.PendingRegistrationTestEntity;
+import io.appform.dropwizard.sharding.dao.testdata.pending.PendingRegistrationTestEntityWithAIId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.stream.Collectors;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Restrictions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -153,5 +157,84 @@ public abstract class DBShardingBundleTestBase extends BundleBasedTestBase {
         bundle.getShardManager().blacklistShard(1);
         //no healthchecks for blacklisting aware bundle
         assertEquals(0, bundle.healthStatus().size());
+    }
+
+    @Test
+    public void testRegisterEntityClassesBeforeRun() {
+        DBShardingBundleBase<TestConfig> bundle = getBundle();
+        bundle.initialize(bootstrap);
+        bundle.registerEntities(PendingRegistrationTestEntity.class, PendingRegistrationTestEntityWithAIId.class);
+        bundle.run(testConfig, environment);
+        assertTrue(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntity.class));
+        assertTrue(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntityWithAIId.class));
+    }
+
+    @Test
+    public void testRegisterAlreadyRegisteredEntityClassesBeforeRun() {
+        DBShardingBundleBase<TestConfig> bundle = getBundle();
+        bundle.initialize(bootstrap);
+        final var alreadyRegisteredEntityClasses = bundle.getInitialisedEntities()
+                .toArray(new Class<?>[0]);
+        Assertions.assertDoesNotThrow(() -> bundle.registerEntities(alreadyRegisteredEntityClasses));
+        Assertions.assertDoesNotThrow(() -> bundle.run(testConfig, environment));
+    }
+
+    @Test
+    public void testRegisterEntityPackagesBeforeRun() {
+        DBShardingBundleBase<TestConfig> bundle = getBundle();
+        bundle.initialize(bootstrap);
+        bundle.registerEntities(List.of("io.appform.dropwizard.sharding.dao.testdata.pending"));
+        bundle.run(testConfig, environment);
+        assertTrue(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntity.class));
+        assertTrue(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntityWithAIId.class));
+    }
+
+    @Test
+    public void testRegisterAlreadyRegisteredEntityPackagesBeforeRun() {
+        DBShardingBundleBase<TestConfig> bundle = getBundle();
+        bundle.initialize(bootstrap);
+        final var alreadyRegisteredEntityPackages = bundle.getInitialisedEntities()
+                .stream()
+                .map(Class::getPackageName)
+                .collect(Collectors.toList());
+        Assertions.assertDoesNotThrow(() -> bundle.registerEntities(alreadyRegisteredEntityPackages));
+        Assertions.assertDoesNotThrow(() -> bundle.run(testConfig, environment));
+    }
+
+    @Test
+    public void testRegisterEntityClassesFailsAfterRun() {
+        DBShardingBundleBase<TestConfig> bundle = getBundle();
+        bundle.initialize(bootstrap);
+        bundle.run(testConfig, environment);
+        final var unsupportedOperationException = Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            bundle.registerEntities(PendingRegistrationTestEntity.class, PendingRegistrationTestEntityWithAIId.class);
+        });
+        assertEquals("Entity registration is not supported after run method execution.",
+                unsupportedOperationException.getMessage());
+        assertFalse(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntity.class));
+        assertFalse(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntityWithAIId.class));
+    }
+
+    @Test
+    public void testRegisterEntityPackagesFailsAfterRun() {
+        DBShardingBundleBase<TestConfig> bundle = getBundle();
+        bundle.initialize(bootstrap);
+        bundle.run(testConfig, environment);
+        final var packagesToRegister = List.of("io.appform.dropwizard.sharding.dao.testdata.pending");
+        final var unsupportedOperationException = Assertions.assertThrows(UnsupportedOperationException.class, () -> {
+            bundle.registerEntities(packagesToRegister);
+        });
+        assertEquals("Entity registration is not supported after run method execution.",
+                unsupportedOperationException.getMessage());
+        assertFalse(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntity.class));
+        assertFalse(bundle.getInitialisedEntities()
+                .contains(PendingRegistrationTestEntityWithAIId.class));
     }
 }

--- a/src/test/java/io/appform/dropwizard/sharding/dao/testdata/pending/PendingRegistrationTestEntity.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/testdata/pending/PendingRegistrationTestEntity.java
@@ -1,0 +1,33 @@
+package io.appform.dropwizard.sharding.dao.testdata.pending;
+
+import io.appform.dropwizard.sharding.sharding.LookupKey;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.validator.constraints.NotEmpty;
+
+@Entity
+@Table(name = "pending_registration_test_entity")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PendingRegistrationTestEntity {
+
+    @Id
+    @NotEmpty
+    @LookupKey
+    @Column(name = "ext_id", unique = true)
+    private String externalId;
+
+    @Column(name = "text", nullable = false)
+    @NotEmpty
+    private String text;
+}

--- a/src/test/java/io/appform/dropwizard/sharding/dao/testdata/pending/PendingRegistrationTestEntityWithAIId.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/testdata/pending/PendingRegistrationTestEntityWithAIId.java
@@ -1,0 +1,37 @@
+package io.appform.dropwizard.sharding.dao.testdata.pending;
+
+import io.appform.dropwizard.sharding.sharding.LookupKey;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "pending_registration_test_entity_with_ai_id")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PendingRegistrationTestEntityWithAIId {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @NotEmpty
+    @LookupKey
+    @Column(name = "ext_id", unique = true)
+    private String externalId;
+
+    @Column(name = "text", nullable = false)
+    @NotEmpty
+    private String text;
+}


### PR DESCRIPTION
### ⚡ TL;DR

This PR introduces an interface in `DbShardingBundle` that allows bundles using `DbShardingBundle` to register their own entity classes before `SessionFactory` initialization. It simplifies integration by removing the need for the integrating service to manually register external entities, reducing coupling and potential for human error.

---

### 🧩 Context

A new Dropwizard bundle named **BundleA** is being developed. This bundle requires database persistence and manages its own entities. To reuse existing database connections initialized via `DbShardingBundle`, **BundleA** accepts a `DbShardingBundle` instance through its constructor. Using this, it creates DAO objects and manages persistence internally.

---

### ❗ Problem

`DbShardingBundle` currently only supports entity registration at the time of its construction. It does not allow entities to be registered afterward. This limitation forces **BundleA** to depend on the integrating service to register its entity classes during `DbShardingBundle` initialization.

This approach introduces potential for human error:

* The service developer may be unaware of the need to register **BundleA**'s entities.
* Even if aware, they may forget or misconfigure the registration.

As a result, the integration becomes fragile, error-prone, and less intuitive—making **BundleA** harder to adopt and integrate cleanly.

---

### ✅ Solution

Expose a new interface in `DbShardingBundle` that allows registration of entity classes **before** the `SessionFactory` is initialized.

With this change:

* **BundleA** can register its own entity classes during the application’s initialization phase (before `run()` is called).
* The service only needs to pass an instance of `DbShardingBundle`—no need to register entities on behalf of **BundleA**.
* The integration becomes cleaner, self-contained, and less prone to errors.

---

### 🎯 Benefits

* Simplifies integration for services consuming **BundleA**.
* Reduces coupling and human error in entity registration.
* Enables a more modular and maintainable contract for bundle developers managing their own entities.
