### PR TITLE
Fix __as_int method

### DIFF
--- a/scripts/find_shard_python3
+++ b/scripts/find_shard_python3
@@ -18,7 +18,7 @@ class FindShard(object):
 
     @staticmethod
     def __as_int(h):
-        return h[0] | numpy.int32(h[1] << 8) | numpy.int32(h[2] << 16) | numpy.int32(h[3] << 24)
+        return h[0] | numpy.int32(h[1]) << 8 | numpy.int32(h[2]) << 16 | numpy.int32(h[3]) << 24
 
     @staticmethod
     def __get_key(k):


### PR DESCRIPTION
The current script breaks with the following error:

```
python3 scripts/find_shard_python3 -k 0M00002506031559112719322803

Traceback (most recent call last):
  File "scripts/find_shard_python3", line 69, in <module>
    bucket_id = FindShard.get_bucket_id(key, options.min_bucket, options.max_bucket)
  File "scripts/find_shard_python3", line 29, in get_bucket_id
    hash_key = FindShard.__as_int(mmh3.hash_bytes(the_key))
  File "scripts/find_shard_python3", line 21, in __as_int
    return h[0] | numpy.int32(h[1] << 8) | numpy.int32(h[2] << 16) | numpy.int32(h[3] << 24)
OverflowError: Python integer 3036676096 out of bounds for int32
```