### PR TITLE
Fix bucket id overflow in LegacyShardManager

### DIFF
--- a/MULTITENANCY.md
+++ b/MULTITENANCY.md
@@ -3,7 +3,7 @@
 Multi tenancy support for sharded databases built on top of the same time and scale tested db sharding framework.
 
 ## Background
-More and more platform services that built using db sharding framework that is being used by multitude of businesses are required to isolate data that is being stored for different businesses. 
+More and more platform services that are built using the db sharding framework that is being used by a multitude of businesses are required to isolate data that is being stored for different businesses. 
 This is where multi-tenancy support comes into play. The db sharding framework is extended to support multi tenancy by adding a tenant id to the same sharding configuration that we are familiar with.
 This allows for asymmetric shard configuration per tenant and also allows for tenant-specific sharding options. 
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The project dependencies are:
 <dependency>
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.10-5</version>
+    <version>2.1.10-11</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.10-10</version>
+    <version>2.1.10-11</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>

--- a/src/main/java/io/appform/dropwizard/sharding/sharding/LegacyShardManager.java
+++ b/src/main/java/io/appform/dropwizard/sharding/sharding/LegacyShardManager.java
@@ -21,10 +21,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
+import java.util.Map;
 import lombok.Builder;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 
 /**
  * Manages shard to bucket mapping.
@@ -32,69 +32,73 @@ import lombok.val;
 @ToString
 @Slf4j
 public class LegacyShardManager extends ShardManager {
-    private static final int MIN_BUCKET = 0;
-    private static final int MAX_BUCKET = 999;
-    private final int numShards;
 
-    private RangeMap<Integer, Integer> buckets = TreeRangeMap.create();
+  private static final int MIN_BUCKET = 0;
+  private static final int MAX_BUCKET = 999;
+  private final int numShards;
 
-    public LegacyShardManager(int numShards) {
-        this(numShards, new InMemoryLocalShardBlacklistingStore());
+  private RangeMap<Integer, Integer> buckets = TreeRangeMap.create();
+
+  public LegacyShardManager(int numShards) {
+    this(numShards, new InMemoryLocalShardBlacklistingStore());
+  }
+
+  @Builder
+  public LegacyShardManager(int numShards, ShardBlacklistingStore shardBlacklistingStore) {
+    super(shardBlacklistingStore);
+    Preconditions.checkArgument(
+        numShards > 1 && ((numShards & (numShards - 1)) == 0),
+        "Shard manager only support 2^n shards." +
+            " Also it is senseless to use anything other than 2^n shards for scale out.");
+    this.numShards = numShards;
+    final RangeMap<Integer, Integer> assignedBuckets = TreeRangeMap.create();
+    int interval = MAX_BUCKET / numShards;
+    log.trace("Interval: {}", interval);
+    int shardCounter = 0;
+    boolean endReached = false;
+    for (int start = MIN_BUCKET; !endReached; start += interval, shardCounter++) {
+      int remaining = MAX_BUCKET - start;
+      log.trace("Remaining: {}. Interval: {}, 2x Interval: {}", remaining, interval, 2 * interval);
+      int end = start + interval - 1;
+      endReached = shardCounter == numShards - 1;
+      end = endReached
+          ? MAX_BUCKET
+          : end;
+      log.trace("Assigning {} elements, from {} to {} into shard {}", end - start + 1, start, end,
+          shardCounter);
+      //End is reached when remaining items (max -
+      assignedBuckets.put(Range.closed(start, end), shardCounter);
     }
+    Preconditions.checkArgument(assignedBuckets.asMapOfRanges().size() == numShards,
+        "There is an issue in shard allocation. " +
+            "Not all shards have been allocated to. Please contact devs.");
+    buckets.putAll(assignedBuckets);
+    log.info("Buckets to shard allocation: {}", buckets);
+  }
 
-    @Builder
-    public LegacyShardManager(int numShards, ShardBlacklistingStore shardBlacklistingStore) {
-        super(shardBlacklistingStore);
-        Preconditions.checkArgument(
-                numShards > 1 && ((numShards & (numShards - 1)) == 0),
-                "Shard manager only support 2^n shards." +
-                        " Also it is senseless to use anything other than 2^n shards for scale out.");
-        this.numShards = numShards;
-        final RangeMap<Integer, Integer> assignedBuckets = TreeRangeMap.create();
-        int interval = MAX_BUCKET / numShards;
-        log.trace("Interval: {}", interval);
-        int shardCounter = 0;
-        boolean endReached = false;
-        boolean altAssignment = ((MAX_BUCKET - (interval * numShards)) > interval);
-        for (int start = MIN_BUCKET; !endReached; start += interval, shardCounter++) {
-            int remaining = MAX_BUCKET - start;
-            log.trace("Remaining: {}. Interval: {}, 2x Interval: {}", remaining, interval, 2 * interval);
-            int end = start + interval - 1;
-            endReached = shardCounter == numShards - 1;
-            end = endReached
-                    ? MAX_BUCKET
-                    : end;
-            log.trace("Assigning {} elements, from {} to {} into shard {}", end - start + 1, start, end, shardCounter);
-            //End is reached when remaining items (max -
-            assignedBuckets.put(Range.closed(start, end), shardCounter);
-        }
-        Preconditions.checkArgument(assignedBuckets.asMapOfRanges().size() == numShards,
-                "There is an issue in shard allocation. " +
-                        "Not all shards have been allocated to. Please contact devs.");
-        buckets.putAll(assignedBuckets);
-        log.info("Buckets to shard allocation: {}", buckets);
+
+  @Override
+  public int numBuckets() {
+    return 1000;
+  }
+
+  @Override
+  public int numShards() {
+    return numShards;
+  }
+
+  @Override
+  protected int shardForBucketImpl(int bucketId) {
+    Map.Entry<Range<Integer>, Integer> entry;
+    if (bucketId >= MIN_BUCKET) {
+      entry = buckets.getEntry(bucketId);
+    } else { // Patch for the overflow bug introduced because numBuckets is not a power of 2.
+      entry = buckets.getEntry(MAX_BUCKET);
     }
-
-
-    @Override
-    public int numBuckets() {
-        return 1000;
+    if (null == entry) {
+      throw new IllegalAccessError("Bucket not mapped to any shard");
     }
-
-    @Override
-    public int numShards() {
-        return numShards;
-    }
-
-    @Override
-    protected int shardForBucketImpl(int bucketId) {
-        Preconditions.checkArgument(bucketId >= MIN_BUCKET && bucketId <= MAX_BUCKET, "Bucket id can only be in the range of [1-1000] (inclusive)");
-        val entry = buckets.getEntry(bucketId);
-        if (null == entry) {
-            throw new IllegalAccessError("Bucket not mapped to any shard");
-        }
-        return entry.getValue();
-    }
-
-
+    return entry.getValue();
+  }
 }
+

--- a/src/test/java/io/appform/dropwizard/sharding/sharding/impl/ConsistentHashBucketIdExtractorTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/sharding/impl/ConsistentHashBucketIdExtractorTest.java
@@ -1,0 +1,29 @@
+package io.appform.dropwizard.sharding.sharding.impl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.appform.dropwizard.sharding.sharding.BalancedShardManager;
+import io.appform.dropwizard.sharding.sharding.LegacyShardManager;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ConsistentHashBucketIdExtractorTest {
+
+  @Test
+  void testBucketIdWithLegacyShardManager() {
+    var shardManager =  new LegacyShardManager(32);
+    ConsistentHashBucketIdExtractor<String> extractor = new ConsistentHashBucketIdExtractor<>(
+        Map.of("tenant1", shardManager));
+    var shardId = shardManager.shardForBucket(extractor.bucketId("tenant1", "MRT2509051351592369928055")) + 1;
+    assertTrue(shardId > 0 && shardId <= 32);
+  }
+
+  @Test
+  void testBucketIdWithBalancedShardManager() {
+    var shardManager =  new BalancedShardManager(32);
+    ConsistentHashBucketIdExtractor<String> extractor = new ConsistentHashBucketIdExtractor<>(
+        Map.of("tenant1", shardManager));
+    var shardId = shardManager.shardForBucket(extractor.bucketId("tenant1", "MRT2509051351592369928055")) + 1;
+    assertTrue(shardId > 0 && shardId <= 32);
+  }
+}


### PR DESCRIPTION
LegacyShardManager has a non power of 2 number of buckets which causes a overflow in bucketId which results in a out of range bucket id. Whenever the overflow happens, the shard manager will always resolve to the last shard.