### PR TITLE
fix: correct readOnly session handling for read and update transaction paths

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/config/ShardingBundleOptions.java
+++ b/src/main/java/io/appform/dropwizard/sharding/config/ShardingBundleOptions.java
@@ -10,8 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ShardingBundleOptions {
-    private boolean skipReadOnlyTransaction = false;
-
     @Builder.Default
     private boolean skipNativeHealthcheck = true;
 

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -413,7 +413,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                     .updater(dao::update)
                     .build();
             return transactionExecutor.get(tenantId)
-                    .<Boolean>execute(dao.sessionFactory, true, "updateImpl", opContext,
+                    .<Boolean>execute(dao.sessionFactory, false, "updateImpl", opContext,
                             shardId);
         } catch (Exception e) {
             throw new RuntimeException("Error updating entity: " + id, e);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -150,8 +150,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer,
-                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
+                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, LookupKey.class);
         Preconditions.checkArgument(fields.length != 0, "At least one field needs to be sharding key");

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -150,7 +150,8 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer));
+                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer,
+                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, LookupKey.class);
         Preconditions.checkArgument(fields.length != 0, "At least one field needs to be sharding key");
@@ -471,7 +472,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                 key -> dao.getLocked(key, criteriaUpdater, LockMode.NONE),
                 null,
                 id,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId), entityClass, observer);
     }
 
@@ -508,7 +509,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                 key -> dao.getLocked(key, criteriaUpdater, LockMode.NONE),
                 entityPopulator,
                 id,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId), entityClass, observer);
     }
 

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -313,8 +313,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer,
-                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
+                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, Id.class);
         Preconditions.checkArgument(fields.length != 0, "A field needs to be designated as @Id");

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -515,7 +515,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 .build();
         try {
             return transactionExecutor.get(tenantId).execute(context.getSessionFactory(),
-                    true,
+                    false,
                     "update",
                     opContext,
                     context.getShardId(), false);
@@ -1059,7 +1059,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
 
         try {
             return transactionExecutor.get(tenantId).execute(context.getSessionFactory(),
-                    true,
+                    false,
                     "createOrUpdate",
                     opContext,
                     context.getShardId(), false);
@@ -1151,7 +1151,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                     .mutator(updater)
                     .updater(dao::update).build();
             return transactionExecutor.get(tenantId)
-                    .<Boolean>execute(dao.sessionFactory, true, "updateAll",
+                    .<Boolean>execute(dao.sessionFactory, false, "updateAll",
                             opContext, shardId);
         } catch (Exception e) {
             throw new RuntimeException("Error updating entity with criteria: " + criteria, e);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -1197,7 +1197,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                     .mutator(updater)
                     .updater(dao::update).build();
             return transactionExecutor.get(tenantId)
-                    .<Boolean>execute(dao.sessionFactory, true, "updateAll",
+                    .<Boolean>execute(dao.sessionFactory, false, "updateAll",
                             opContext, shardId);
         } catch (Exception e) {
             throw new RuntimeException("Error updating entity with criteria: " + querySpec, e);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -563,7 +563,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 .build();
         try {
             return transactionExecutor.get(tenantId).execute(context.getSessionFactory(),
-                    true,
+                    false,
                     "update",
                     opContext,
                     context.getShardId(), false);
@@ -1095,7 +1095,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
 
         try {
             return transactionExecutor.get(tenantId).execute(context.getSessionFactory(),
-                    true,
+                    false,
                     "createOrUpdate",
                     opContext,
                     context.getShardId(), false);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -871,7 +871,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 .mutator(updater)
                 .updater(dao::update).build();
         try {
-            return transactionExecutor.get(tenantId).execute(daoSessionFactory, true, "update",
+            return transactionExecutor.get(tenantId).execute(daoSessionFactory, false, "update",
                     opContext, shardId, completeTransaction);
         } catch (Exception e) {
             throw new RuntimeException("Error updating entity: " + id, e);
@@ -895,7 +895,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 .updater(dao::update).build();
         try {
             return transactionExecutor.get(tenantId).execute(dao.sessionFactory,
-                    true,
+                    false,
                     "update",
                     opContext,
                     shardId);
@@ -942,7 +942,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 .updater(dao::update).build();
         try {
             return transactionExecutor.get(tenantId).execute(dao.sessionFactory,
-                    true,
+                    false,
                     "update",
                     opContext,
                     shardId);

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -313,7 +313,8 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer));
+                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer,
+                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, Id.class);
         Preconditions.checkArgument(fields.length != 0, "A field needs to be designated as @Id");
@@ -1607,7 +1608,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> Lists.newArrayList(dao.getLocked(key, criteriaUpdater, LockMode.NONE)),
                 entityPopulator,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,
@@ -1656,7 +1657,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> dao.select(selectParam),
                 entityPopulator,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,
@@ -1706,7 +1707,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> dao.select(selectParam),
                 entityPopulator,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Count.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Count.java
@@ -27,6 +27,11 @@ public class Count extends OpContext<Long> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.COUNT;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/CountByQuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/CountByQuerySpec.java
@@ -27,6 +27,11 @@ public class CountByQuerySpec extends OpContext<Long> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.COUNT_BY_QUERY_SPEC;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Get.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Get.java
@@ -32,6 +32,11 @@ public class Get<T, R> extends OpContext<R> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.GET;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/OpContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/OpContext.java
@@ -23,6 +23,10 @@ import java.util.function.Function;
 public abstract class OpContext<T> implements Function<Session, T> {
   public abstract OpType getOpType();
 
+  public boolean isTransactionOptional() {
+    return false;
+  }
+
   public abstract <P> P visit(OpContextVisitor<P> visitor);
 
   public interface OpContextVisitor<P> {

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Select.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Select.java
@@ -34,6 +34,11 @@ public class Select<T, R> extends OpContext<R> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.SELECT;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
@@ -53,8 +53,9 @@ public class CreateOrUpdateByLookupKey<T> extends OpContext<T> {
     val updated = mutator.apply(result);
     if (null != updated) {
       updater.accept(updated);
+      return getter.apply(id);
     }
-    return getter.apply(id);
+    return result;
   }
 
   @Override

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
@@ -53,7 +53,7 @@ public class CreateOrUpdateByLookupKey<T> extends OpContext<T> {
     val updated = mutator.apply(result);
     if (null != updated) {
       updater.accept(updated);
-      return getter.apply(id);
+      return updated;
     }
     return result;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/GetByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/GetByLookupKey.java
@@ -33,6 +33,11 @@ public class GetByLookupKey<T, R> extends OpContext<R> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.GET_BY_LOOKUP_KEY;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
+++ b/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
@@ -33,15 +33,25 @@ public class TransactionExecutor {
     private final Class<?> entityClass;
     private final ShardInfoProvider shardInfoProvider;
     private final TransactionObserver observer;
+    private final boolean skipReadOnlyTransaction;
 
     public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
                                final DaoType daoType,
                                final Class<?> entityClass,
                                final TransactionObserver observer) {
+        this(shardInfoProvider, daoType, entityClass, observer, false);
+    }
+
+    public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
+                               final DaoType daoType,
+                               final Class<?> entityClass,
+                               final TransactionObserver observer,
+                               final boolean skipReadOnlyTransaction) {
         this.daoType = daoType;
         this.entityClass = entityClass;
         this.shardInfoProvider = shardInfoProvider;
         this.observer = observer;
+        this.skipReadOnlyTransaction = skipReadOnlyTransaction;
     }
 
     public <T> T execute(SessionFactory sessionFactory,
@@ -66,7 +76,8 @@ public class TransactionExecutor {
             .opContext(opContext)
             .build();
         return observer.execute(context, () -> {
-            val transactionHandler = new TransactionHandler(sessionFactory, readOnly);
+            val transactionHandler = new TransactionHandler(sessionFactory, readOnly,
+                skipReadOnlyTransaction && opContext.isTransactionOptional());
             if (completeTransaction) {
                 transactionHandler.beforeStart();
             }

--- a/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
+++ b/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
@@ -33,25 +33,14 @@ public class TransactionExecutor {
     private final Class<?> entityClass;
     private final ShardInfoProvider shardInfoProvider;
     private final TransactionObserver observer;
-    private final boolean skipReadOnlyTransaction;
-
     public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
                                final DaoType daoType,
                                final Class<?> entityClass,
                                final TransactionObserver observer) {
-        this(shardInfoProvider, daoType, entityClass, observer, false);
-    }
-
-    public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
-                               final DaoType daoType,
-                               final Class<?> entityClass,
-                               final TransactionObserver observer,
-                               final boolean skipReadOnlyTransaction) {
         this.daoType = daoType;
         this.entityClass = entityClass;
         this.shardInfoProvider = shardInfoProvider;
         this.observer = observer;
-        this.skipReadOnlyTransaction = skipReadOnlyTransaction;
     }
 
     public <T> T execute(SessionFactory sessionFactory,
@@ -77,7 +66,7 @@ public class TransactionExecutor {
             .build();
         return observer.execute(context, () -> {
             val transactionHandler = new TransactionHandler(sessionFactory, readOnly,
-                skipReadOnlyTransaction && opContext.isTransactionOptional());
+                opContext.isTransactionOptional());
             if (completeTransaction) {
                 transactionHandler.beforeStart();
             }

--- a/src/main/java/io/appform/dropwizard/sharding/hibernate/SessionFactoryFactory.java
+++ b/src/main/java/io/appform/dropwizard/sharding/hibernate/SessionFactoryFactory.java
@@ -48,6 +48,7 @@ public abstract class SessionFactoryFactory<T> implements DatabaseConfiguration<
 
     public SessionFactorySource build(T configuration, Environment environment) throws Exception {
         final PooledDataSourceFactory dbConfig = getDataSourceFactory(configuration);
+        dbConfig.getProperties().put("defaultAutoCommit", "false");
         final ManagedDataSource dataSource = dbConfig.build(environment.metrics(), name());
         final ConnectionProvider provider = buildConnectionProvider(dataSource, dbConfig.getProperties());
         this.sessionFactory = buildSessionFactory(
@@ -94,6 +95,8 @@ public abstract class SessionFactoryFactory<T> implements DatabaseConfiguration<
         for (Map.Entry<String, String> property : properties.entrySet()) {
             configuration.setProperty(property.getKey(), property.getValue());
         }
+        // Must be set after user properties to prevent override — pair with defaultAutoCommit=false on the pool
+        configuration.setProperty(AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, "true");
         addAnnotatedClasses(configuration, entities);
         final ServiceRegistry registry = new StandardServiceRegistryBuilder(bootstrapServiceRegistry)
                 .addService(ConnectionProvider.class, connectionProvider)

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
@@ -98,7 +98,7 @@ public class LockTest {
             sessionFactories.add(sessionFactory);
         }
         final ShardManager shardManager = new BalancedShardManager(sessionFactories.size());
-        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().skipReadOnlyTransaction(true).build();
+        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().build();
         final ShardInfoProvider shardInfoProvider = new ShardInfoProvider("default");
         lookupDao = new LookupDao<>(DBShardingBundleBase.DEFAULT_NAMESPACE,
                 new MultiTenantLookupDao<>(Map.of(DBShardingBundleBase.DEFAULT_NAMESPACE, sessionFactories),

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/ParentChildTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/ParentChildTest.java
@@ -46,7 +46,7 @@ public class ParentChildTest {
             sessionFactories.add(sessionFactory);
         }
         final ShardManager shardManager = new BalancedShardManager(sessionFactories.size());
-        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().skipReadOnlyTransaction(true).build();
+        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().build();
         final ShardInfoProvider shardInfoProvider = new ShardInfoProvider("default");
 
         parentClassRelationalDao = new RelationalDao<>(DBShardingBundleBase.DEFAULT_NAMESPACE,


### PR DESCRIPTION
  Description:

  Problem

  Two separate session readOnly bugs existed in the DAO transaction paths:

  1. skipReadOnlyTransaction applied to the wrong layer skipReadOnlyTransaction was wired to ReadOnlyContext (the chainable multi-read executor). Skipping the transaction there breaks InnoDB REPEATABLE READ —
  child reads start independent transactions and get different MVCC snapshots than the parent, causing torn reads.

  2. Update paths ran in readOnly=true sessions GetAndUpdate, SelectAndUpdate (RelationalDao) and GetAndUpdateByLookupKey (LookupDao) were executing with readOnly=true. TransactionHandler propagates this to
  session.setDefaultReadOnly(true), which disables dirty-checking snapshots — so entities loaded in those sessions are never flushed and updates are silently lost.

  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

  Fix

  Commit 1 — skipReadOnlyTransaction scoped to safe single-query ops only:

   - Added OpContext.isTransactionOptional() (default false)
   - Overridden to true in Get, GetByLookupKey, Select, Count, CountByQuerySpec — these issue a single DB call with no subsequent session-bound work, so skipping the transaction is safe
   - ReadOnlyContext chains always keep their transaction (shared MVCC snapshot)
   - TransactionExecutor honours skipReadOnlyTransaction only when opContext.isTransactionOptional() == true

  Commit 2 — Update execute paths use readOnly=false:

   - GetAndUpdate, both SelectAndUpdate overloads → readOnly=false
   - GetAndUpdateByLookupKey → readOnly=false
   - Dirty checking now fires correctly at flush; updates are no longer lost