### PR TITLE
fix: resolve @PartitionKey NPE by fixing read-only session flag and persist() detach handling

### DIFF
--- a/db-sharding-bundle-dependencies/pom.xml
+++ b/db-sharding-bundle-dependencies/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.dropwizard.sharding</groupId>
         <artifactId>db-sharding-bundle-root</artifactId>
-        <version>2.1.12-HIBERNATE6-RC2</version>
+        <version>2.1.12-HIBERNATE6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/db-sharding-bundle-parent/pom.xml
+++ b/db-sharding-bundle-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.dropwizard.sharding</groupId>
         <artifactId>db-sharding-bundle-root</artifactId>
-        <version>2.1.12-HIBERNATE6-RC2</version>
+        <version>2.1.12-HIBERNATE6-SNAPSHOT</version>
     </parent>
 
     <artifactId>db-sharding-bundle-parent</artifactId>

--- a/db-sharding-bundle/pom.xml
+++ b/db-sharding-bundle/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.appform.dropwizard.sharding</groupId>
         <artifactId>db-sharding-bundle-parent</artifactId>
-        <version>2.1.12-HIBERNATE6-RC2</version>
+        <version>2.1.12-HIBERNATE6-SNAPSHOT</version>
         <relativePath>../db-sharding-bundle-parent/pom.xml</relativePath>
     </parent>
 

--- a/db-sharding-bundle/src/main/java/io/appform/dropwizard/sharding/dao/AbstractDAO.java
+++ b/db-sharding-bundle/src/main/java/io/appform/dropwizard/sharding/dao/AbstractDAO.java
@@ -180,11 +180,44 @@ public class AbstractDAO<E> {
      *
      * @param entity a transient or detached instance containing new or updated state
      * @throws HibernateException
-     * @see Session#saveOrUpdate(Object)
      */
+    @SuppressWarnings("unchecked")
     protected E persist(E entity) throws HibernateException {
-        currentSession().saveOrUpdate(requireNonNull(entity));
+        final Session session = currentSession();
+        if (session.contains(requireNonNull(entity))) {
+            // Already managed in this session — dirty checking will flush changes at commit.
+            return entity;
+        }
+        final Object id = session.getSessionFactory()
+                .getPersistenceUnitUtil()
+                .getIdentifier(entity);
+        if (isAssignedId(id)) {
+            // Detached entity (has an existing DB id, not currently in session).
+            // session.saveOrUpdate() re-attaches without a DB read, leaving loadedState=null,
+            // which causes an NPE in @PartitionKey WHERE-clause binding at flush time.
+            // session.merge() does a SELECT first, populating loadedState safely.
+            return (E) session.merge(entity);
+        }
+        // Transient (new) entity — saveOrUpdate inserts and sets the generated id in-place.
+        session.saveOrUpdate(entity);
         return entity;
+    }
+
+    /**
+     * Returns true if {@code id} represents an already-assigned (non-default) identifier,
+     * i.e. the entity is detached rather than transient.
+     */
+    private static boolean isAssignedId(Object id) {
+        if (id == null) {
+            return false;
+        }
+        if (id instanceof Number) {
+            return ((Number) id).longValue() != 0;
+        }
+        if (id instanceof String) {
+            return !((String) id).isEmpty();
+        }
+        return true;
     }
 
     /**

--- a/db-sharding-bundle/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/db-sharding-bundle/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -407,7 +407,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                     .updater(dao::update)
                     .build();
             return transactionExecutor.get(tenantId)
-                    .<Boolean>execute(dao.sessionFactory, true, "updateImpl", opContext,
+                    .<Boolean>execute(dao.sessionFactory, false, "updateImpl", opContext,
                             shardId);
         } catch (Exception e) {
             throw new RuntimeException("Error updating entity: " + id, e);
@@ -1275,15 +1275,16 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         }
 
         /**
-         * Updates the state of an entity in the shard. The entity is first detached from the current
-         * session to ensure that updates are performed. The updated entity is then associated with the
-         * session for synchronization.
+         * Updates the state of an entity in the shard. Since the entity is already managed
+         * within the current session (loaded by the preceding get), dirty checking handles
+         * flushing changes automatically at commit time.
          *
          * @param entity The entity to be updated in the shard.
          */
         void update(T entity) {
-            currentSession().evict(entity); //Detach .. otherwise update is a no-op
-            currentSession().update(entity);
+            // Entity is already managed in this session; dirty checking flushes changes at commit.
+            // Evicting and re-attaching via session.update() would null out loadedState,
+            // breaking @PartitionKey WHERE-clause binding.
         }
 
         /**

--- a/db-sharding-bundle/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/db-sharding-bundle/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -173,8 +173,9 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
         }
 
         void update(T oldEntity, T entity) {
-            currentSession().evict(oldEntity); //Detach ... otherwise update is a no-op
-            currentSession().update(entity);
+            // Entity is already managed in this session; dirty checking flushes changes at commit.
+            // Evicting and re-attaching via session.update() would null out loadedState,
+            // breaking @PartitionKey WHERE-clause binding.
         }
 
         List<T> select(SelectParam selectParam) {
@@ -738,7 +739,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 .mutator(updater)
                 .updater(dao::update).build();
         try {
-            return transactionExecutor.get(tenantId).execute(daoSessionFactory, true, "update",
+            return transactionExecutor.get(tenantId).execute(daoSessionFactory, false, "update",
                     opContext, shardId, completeTransaction);
         } catch (Exception e) {
             throw new RuntimeException("Error updating entity: " + id, e);
@@ -782,7 +783,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 .updater(dao::update).build();
         try {
             return transactionExecutor.get(tenantId).execute(dao.sessionFactory,
-                    true,
+                    false,
                     "update",
                     opContext,
                     shardId);

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle-root</artifactId>
-    <version>2.1.12-HIBERNATE6-RC2</version>
+    <version>2.1.12-HIBERNATE6-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Dropwizard Database Sharding Bundle Root</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>


### PR DESCRIPTION
- Change update transaction sessions from readOnly=true to readOnly=false in MultiTenantRelationalDao (GetAndUpdate, SelectAndUpdate) and MultiTenantLookupDao (GetAndUpdateByLookupKey). Update operations were running in read-only sessions, which disabled dirty-checking snapshots and meant entities were never flushed. The evict+update workaround had masked this but broke Hibernate 6.2+ @PartitionKey support (loadedState is null for re-attached entities).

- Fix AbstractDAO.persist() to use merge() for detached entities with an assigned id (id > 0), so that loadedState is populated before any flush. New entities (id=0) continue to use saveOrUpdate() for in-place id mutation.

- Remove the evict+update pattern from MultiTenantLookupDao.update() and MultiTenantRelationalDao.update(); dirty-checking now handles flushes correctly since sessions are no longer marked read-only.

- Bump version to 2.1.12-HIBERNATE6-SNAPSHOT for local verification (to be updated before final release).