### PR TITLE
perf: fix transaction-skipping scope and eliminate autocommit round-trips

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -150,7 +150,8 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer));
+                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer,
+                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, LookupKey.class);
         Preconditions.checkArgument(fields.length != 0, "At least one field needs to be sharding key");
@@ -471,7 +472,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                 key -> dao.getLocked(key, criteriaUpdater, LockMode.NONE),
                 null,
                 id,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId), entityClass, observer);
     }
 
@@ -508,7 +509,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                 key -> dao.getLocked(key, criteriaUpdater, LockMode.NONE),
                 entityPopulator,
                 id,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId), entityClass, observer);
     }
 

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -313,7 +313,8 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer));
+                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer,
+                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, Id.class);
         Preconditions.checkArgument(fields.length != 0, "A field needs to be designated as @Id");
@@ -1607,7 +1608,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> Lists.newArrayList(dao.getLocked(key, criteriaUpdater, LockMode.NONE)),
                 entityPopulator,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,
@@ -1656,7 +1657,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> dao.select(selectParam),
                 entityPopulator,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,
@@ -1706,7 +1707,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> dao.select(selectParam),
                 entityPopulator,
-                shardingOptions.get(tenantId).isSkipReadOnlyTransaction(),
+                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Count.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Count.java
@@ -27,6 +27,11 @@ public class Count extends OpContext<Long> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.COUNT;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/CountByQuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/CountByQuerySpec.java
@@ -27,6 +27,11 @@ public class CountByQuerySpec extends OpContext<Long> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.COUNT_BY_QUERY_SPEC;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Get.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Get.java
@@ -32,6 +32,11 @@ public class Get<T, R> extends OpContext<R> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.GET;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/OpContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/OpContext.java
@@ -23,6 +23,10 @@ import java.util.function.Function;
 public abstract class OpContext<T> implements Function<Session, T> {
   public abstract OpType getOpType();
 
+  public boolean isTransactionOptional() {
+    return false;
+  }
+
   public abstract <P> P visit(OpContextVisitor<P> visitor);
 
   public interface OpContextVisitor<P> {

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Select.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Select.java
@@ -34,6 +34,11 @@ public class Select<T, R> extends OpContext<R> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.SELECT;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/GetByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/GetByLookupKey.java
@@ -33,6 +33,11 @@ public class GetByLookupKey<T, R> extends OpContext<R> {
   }
 
   @Override
+  public boolean isTransactionOptional() {
+    return true;
+  }
+
+  @Override
   public OpType getOpType() {
     return OpType.GET_BY_LOOKUP_KEY;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
+++ b/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
@@ -33,15 +33,25 @@ public class TransactionExecutor {
     private final Class<?> entityClass;
     private final ShardInfoProvider shardInfoProvider;
     private final TransactionObserver observer;
+    private final boolean skipReadOnlyTransaction;
 
     public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
                                final DaoType daoType,
                                final Class<?> entityClass,
                                final TransactionObserver observer) {
+        this(shardInfoProvider, daoType, entityClass, observer, false);
+    }
+
+    public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
+                               final DaoType daoType,
+                               final Class<?> entityClass,
+                               final TransactionObserver observer,
+                               final boolean skipReadOnlyTransaction) {
         this.daoType = daoType;
         this.entityClass = entityClass;
         this.shardInfoProvider = shardInfoProvider;
         this.observer = observer;
+        this.skipReadOnlyTransaction = skipReadOnlyTransaction;
     }
 
     public <T> T execute(SessionFactory sessionFactory,
@@ -66,7 +76,8 @@ public class TransactionExecutor {
             .opContext(opContext)
             .build();
         return observer.execute(context, () -> {
-            val transactionHandler = new TransactionHandler(sessionFactory, readOnly);
+            val transactionHandler = new TransactionHandler(sessionFactory, readOnly,
+                skipReadOnlyTransaction && opContext.isTransactionOptional());
             if (completeTransaction) {
                 transactionHandler.beforeStart();
             }

--- a/src/main/java/io/appform/dropwizard/sharding/hibernate/SessionFactoryFactory.java
+++ b/src/main/java/io/appform/dropwizard/sharding/hibernate/SessionFactoryFactory.java
@@ -48,6 +48,7 @@ public abstract class SessionFactoryFactory<T> implements DatabaseConfiguration<
 
     public SessionFactorySource build(T configuration, Environment environment) throws Exception {
         final PooledDataSourceFactory dbConfig = getDataSourceFactory(configuration);
+        dbConfig.getProperties().put("defaultAutoCommit", "false");
         final ManagedDataSource dataSource = dbConfig.build(environment.metrics(), name());
         final ConnectionProvider provider = buildConnectionProvider(dataSource, dbConfig.getProperties());
         this.sessionFactory = buildSessionFactory(
@@ -94,6 +95,8 @@ public abstract class SessionFactoryFactory<T> implements DatabaseConfiguration<
         for (Map.Entry<String, String> property : properties.entrySet()) {
             configuration.setProperty(property.getKey(), property.getValue());
         }
+        // Must be set after user properties to prevent override — pair with defaultAutoCommit=false on the pool
+        configuration.setProperty(AvailableSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, "true");
         addAnnotatedClasses(configuration, entities);
         final ServiceRegistry registry = new StandardServiceRegistryBuilder(bootstrapServiceRegistry)
                 .addService(ConnectionProvider.class, connectionProvider)


### PR DESCRIPTION
## Problem

   `skipReadOnlyTransaction=true` in `ShardingBundleOptions` was intended to skip
   Hibernate transaction overhead for read operations. It was broken — it applied
   the skip to `ReadOnlyContext` chains (`readAugmentParent`), which broke InnoDB
   REPEATABLE READ. Child reads started their own transaction and got a different
   MVCC snapshot than the parent, causing torn reads.

   Additionally, every Hibernate transaction (read or write) was paying 2 extra DB
   round-trips: `SET autocommit=0` before and `SET autocommit=1` after. These are
   unnecessary when the connection pool already manages autocommit state.


 ## Changes

 ### 1. Fix transaction-skipping scope via `OpContext.isTransactionOptional()`

 Added `OpContext.isTransactionOptional()` (default `false`). The 5 safe
 single-query read ops override it to `true`:

 - `Get`, `GetByLookupKey`, `Select`, `Count`, `CountByQuerySpec`

 These are safe because they issue exactly one DB call with no subsequent
 session-bound work. `TransactionExecutor` now skips the transaction wrapper only
 when `isTransactionOptional()=true` **and** `skipReadOnlyTransaction=true`.

 `ReadOnlyContext` chains always run in a transaction regardless of the flag,
 preserving MVCC snapshot consistency across chained reads.

 ### 2. Eliminate `SET autocommit=0` / `SET autocommit=1` round-trips

 - `defaultAutoCommit=false` forced on the Tomcat JDBC pool before `build()`,
   so connections leave the pool with autocommit already off
 - `hibernate.connection.provider_disables_autocommit=true` set **after** the
   user properties loop so it cannot be overridden via YAML `properties:`

 Both are applied as an atomic pair — one without the other silently breaks
 transaction semantics. Neither is user-configurable.

 ## Net effect

 Every transaction saves 2 DB round-trips. Single-query reads additionally skip
 `BEGIN`/`COMMIT` when `skipReadOnlyTransaction=true`.