### PR TITLE
refactor: remove skipReadOnlyTransaction config flag

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/config/ShardingBundleOptions.java
+++ b/src/main/java/io/appform/dropwizard/sharding/config/ShardingBundleOptions.java
@@ -10,8 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ShardingBundleOptions {
-    private boolean skipReadOnlyTransaction = false;
-
     @Builder.Default
     private boolean skipNativeHealthcheck = true;
 

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -150,8 +150,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer,
-                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
+                    new TransactionExecutor(shardInfoProvider, DaoType.LOOKUP, entityClass, observer));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, LookupKey.class);
         Preconditions.checkArgument(fields.length != 0, "At least one field needs to be sharding key");

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -313,8 +313,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
         this.observer = observer;
         shardInfoProviders.forEach((tenantId, shardInfoProvider) -> {
             this.transactionExecutor.put(tenantId,
-                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer,
-                            shardingOptions.get(tenantId).isSkipReadOnlyTransaction()));
+                    new TransactionExecutor(shardInfoProvider, DaoType.RELATIONAL, entityClass, observer));
         });
         Field[] fields = FieldUtils.getFieldsWithAnnotation(entityClass, Id.class);
         Preconditions.checkArgument(fields.length != 0, "A field needs to be designated as @Id");

--- a/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
+++ b/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
@@ -33,25 +33,14 @@ public class TransactionExecutor {
     private final Class<?> entityClass;
     private final ShardInfoProvider shardInfoProvider;
     private final TransactionObserver observer;
-    private final boolean skipReadOnlyTransaction;
-
     public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
                                final DaoType daoType,
                                final Class<?> entityClass,
                                final TransactionObserver observer) {
-        this(shardInfoProvider, daoType, entityClass, observer, false);
-    }
-
-    public TransactionExecutor(final ShardInfoProvider shardInfoProvider,
-                               final DaoType daoType,
-                               final Class<?> entityClass,
-                               final TransactionObserver observer,
-                               final boolean skipReadOnlyTransaction) {
         this.daoType = daoType;
         this.entityClass = entityClass;
         this.shardInfoProvider = shardInfoProvider;
         this.observer = observer;
-        this.skipReadOnlyTransaction = skipReadOnlyTransaction;
     }
 
     public <T> T execute(SessionFactory sessionFactory,
@@ -77,7 +66,7 @@ public class TransactionExecutor {
             .build();
         return observer.execute(context, () -> {
             val transactionHandler = new TransactionHandler(sessionFactory, readOnly,
-                skipReadOnlyTransaction && opContext.isTransactionOptional());
+                opContext.isTransactionOptional());
             if (completeTransaction) {
                 transactionHandler.beforeStart();
             }

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
@@ -98,7 +98,7 @@ public class LockTest {
             sessionFactories.add(sessionFactory);
         }
         final ShardManager shardManager = new BalancedShardManager(sessionFactories.size());
-        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().skipReadOnlyTransaction(true).build();
+        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().build();
         final ShardInfoProvider shardInfoProvider = new ShardInfoProvider("default");
         lookupDao = new LookupDao<>(DBShardingBundleBase.DEFAULT_NAMESPACE,
                 new MultiTenantLookupDao<>(Map.of(DBShardingBundleBase.DEFAULT_NAMESPACE, sessionFactories),

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/ParentChildTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/ParentChildTest.java
@@ -46,7 +46,7 @@ public class ParentChildTest {
             sessionFactories.add(sessionFactory);
         }
         final ShardManager shardManager = new BalancedShardManager(sessionFactories.size());
-        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().skipReadOnlyTransaction(true).build();
+        final ShardingBundleOptions shardingOptions = ShardingBundleOptions.builder().build();
         final ShardInfoProvider shardInfoProvider = new ShardInfoProvider("default");
 
         parentClassRelationalDao = new RelationalDao<>(DBShardingBundleBase.DEFAULT_NAMESPACE,


### PR DESCRIPTION
   ## Context

   Depends on: `fix/transaction-optimization`

   `skipReadOnlyTransaction` in `ShardingBundleOptions` was introduced as an
   opt-in flag to skip transaction overhead for read operations. The previous MR
   (`fix/transaction-optimization`) fixed its broken scope by introducing
   `OpContext.isTransactionOptional()`, which correctly identifies the 5 safe
   single-query ops where skipping is valid.

   With that abstraction in place, the external config flag is redundant —
   `isTransactionOptional()` is the real guard and it already makes the right
   decision per op-type. The flag just gates an optimization that is always safe
   to enable.

   ## Changes

   - Removed `skipReadOnlyTransaction` from `ShardingBundleOptions`
   - `TransactionExecutor` collapsed to a single constructor — no longer accepts
     the flag; honours `opContext.isTransactionOptional()` unconditionally
   - `MultiTenantLookupDao` and `MultiTenantRelationalDao` constructors updated
     to use the single-arg `TransactionExecutor`
   - Test builders updated to remove `.skipReadOnlyTransaction(true)`

   ## Breaking change

   > ⚠️ `skipReadOnlyTransaction` is removed from `ShardingBundleOptions`.
   > Any code or YAML referencing it will fail to compile / be ignored.
   > Simply remove the field from your configuration — the optimization is
   > now always-on for safe single-query read ops.