### PR TITLE
perf: skip redundant SELECTs in createOrUpdate

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
@@ -53,8 +53,9 @@ public class CreateOrUpdateByLookupKey<T> extends OpContext<T> {
     val updated = mutator.apply(result);
     if (null != updated) {
       updater.accept(updated);
+      return getter.apply(id);
     }
-    return getter.apply(id);
+    return result;
   }
 
   @Override

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
@@ -53,7 +53,7 @@ public class CreateOrUpdateByLookupKey<T> extends OpContext<T> {
     val updated = mutator.apply(result);
     if (null != updated) {
       updater.accept(updated);
-      return getter.apply(id);
+      return updated;
     }
     return result;
   }


### PR DESCRIPTION
 `CreateOrUpdateByLookupKey.apply()` was calling `getter.apply(id)` (a SELECT)
 at the end of every path, even when the entity was already in memory.

 **When mutator returns non-null (entity updated):** Hibernate refreshes
 generated fields on the `updated` entity in-memory after flush — no need to
 re-fetch. Return `updated` directly.

 **When mutator returns null (no update needed):** `result` was just loaded from
 DB under a lock — it's already current state. Return `result` directly.

 Saves one SELECT per `createOrUpdate` call in both paths.