### PR TITLE
Bump version to 2.1.12-4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.12-3</version>
+    <version>2.1.12-4</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>


### PR DESCRIPTION
Bumps artifact version from 2.1.12-3 to 2.1.12-4 following the merge of https://github.com/santanusinha/dropwizard-db-sharding-bundle/pull/155