### PR TITLE
perf: return updated entity directly, skip post-update getter SELECT

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
@@ -55,7 +55,7 @@ public class CreateOrUpdateByLookupKey<T> extends OpContext<T> {
       return result;
     }
     updater.accept(updated);
-    return getter.apply(id);
+    return updated;
   }
 
   @Override

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/CreateOrUpdateByLookupKey.java
@@ -51,9 +51,10 @@ public class CreateOrUpdateByLookupKey<T> extends OpContext<T> {
       return null;
     }
     val updated = mutator.apply(result);
-    if (null != updated) {
-      updater.accept(updated);
+    if (null == updated) {
+      return result;
     }
+    updater.accept(updated);
     return getter.apply(id);
   }
 


### PR DESCRIPTION
   Depends on: `perf/create-or-update-skip-null-path`

   After `updater.accept(updated)` flushes the UPDATE, Hibernate refreshes
   generated fields (e.g. `updated_at`) in-memory on the `updated` entity.
   The subsequent `getter.apply(id)` SELECT was redundant — return `updated` directly.
