### PR TITLE
Added logs to print the original exception during DB exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.12-7]
+- Added logs to print the original exception during DB exception handling.
+
+  **Reason**: For DB-related exceptions, rollback is attempted in the `catch` block and then the exception is rethrown.
+  - If rollback also fails (for example, due to a database connectivity issue), the rollback exception can override the original exception.
+  - Logging the original exception preserves the root cause and improves debugging.
+
 ## [2.1.10-10]
 - Added changes for new central deployment.
 - Exposed interface for entity registration in `DbShardingBundle`. ([#130](https://github.com/santanusinha/dropwizard-db-sharding-bundle/pull/130))

--- a/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
+++ b/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
@@ -21,12 +21,14 @@ import io.appform.dropwizard.sharding.ShardInfoProvider;
 import io.appform.dropwizard.sharding.dao.operations.OpContext;
 import io.appform.dropwizard.sharding.observers.TransactionObserver;
 import io.appform.dropwizard.sharding.utils.TransactionHandler;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.hibernate.SessionFactory;
 
 /**
  * Utility functional class for running transactions.
  */
+@Slf4j
 public class TransactionExecutor {
 
     private final DaoType daoType;
@@ -77,6 +79,7 @@ public class TransactionExecutor {
                 }
                 return result;
             } catch (Exception e) {
+                log.error("Error executing transaction", e);
                 if (completeTransaction) {
                     transactionHandler.onError();
                 }


### PR DESCRIPTION
For DB-related exceptions, rollback is attempted in the `catch` block and then the exception is rethrown.
  - If rollback also fails (for example, due to a database connectivity issue), the rollback exception can override the original exception.
  - Logging the original exception preserves the root cause and improves debugging.