### PR TITLE
Make session reuse configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dep
 out
 .project
 .settings
+.worktrees

--- a/src/main/java/io/appform/dropwizard/sharding/MultiTenantDBShardingBundleBase.java
+++ b/src/main/java/io/appform/dropwizard/sharding/MultiTenantDBShardingBundleBase.java
@@ -51,6 +51,7 @@ import io.appform.dropwizard.sharding.sharding.EntityMeta;
 import io.appform.dropwizard.sharding.sharding.ShardBlacklistingStore;
 import io.appform.dropwizard.sharding.sharding.ShardManager;
 import io.appform.dropwizard.sharding.sharding.impl.ConsistentHashBucketIdExtractor;
+import io.appform.dropwizard.sharding.utils.TransactionHandler;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Bootstrap;
@@ -157,7 +158,13 @@ public abstract class MultiTenantDBShardingBundleBase<T extends Configuration> e
                 .stream()
                 .map(SessionFactorySource::getFactory)
                 .collect(Collectors.toList());
-        sessionFactory.forEach(factory -> factory.getProperties().put("tenant.id", tenantId));
+        final boolean sessionReuseEnabled = shardingOption.isTransactionSessionReuseEnabled();
+        sessionFactory.forEach(factory -> {
+          factory.getProperties().put("tenant.id", tenantId);
+          factory.getProperties().put(
+                  TransactionHandler.SESSION_REUSE_ENABLED,
+                  sessionReuseEnabled);
+        });
         if (shardingOption.isEncryptionSupportEnabled()) {
           Preconditions.checkArgument(shardingOption.getEncryptionIv().length() == 16,
                   "Encryption IV Should be 16 bytes long");

--- a/src/main/java/io/appform/dropwizard/sharding/config/ShardingBundleOptions.java
+++ b/src/main/java/io/appform/dropwizard/sharding/config/ShardingBundleOptions.java
@@ -11,6 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ShardingBundleOptions {
     @Builder.Default
+    private boolean transactionSessionReuseEnabled = true;
+
+    @Builder.Default
     private boolean skipNativeHealthcheck = true;
 
     @Builder.Default

--- a/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
+++ b/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
@@ -34,6 +34,7 @@ public class TransactionHandler {
 
 
     public static final String TENANT_ID = "tenant.id";
+    public static final String SESSION_REUSE_ENABLED = "db.sharding.transaction.session.reuse.enabled";
     // Context variables
     @Getter
     private Session session;
@@ -81,7 +82,7 @@ public class TransactionHandler {
     @SuppressWarnings("java:S1181")
     public void beforeStart() {
         try {
-            if (ManagedSessionContext.hasBind(sessionFactory)) {
+            if (isSessionReuseEnabled() && ManagedSessionContext.hasBind(sessionFactory)) {
                 session = sessionFactory.getCurrentSession();
                 final var existingTransaction = session.getTransaction();
                 skipCommit = existingTransaction != null && existingTransaction.isActive();
@@ -143,6 +144,13 @@ public class TransactionHandler {
                 MDC.remove(TENANT_ID);
             }
         }
+    }
+
+    private boolean isSessionReuseEnabled() {
+        final Object configuredValue = sessionFactory.getProperties() == null
+                ? null
+                : sessionFactory.getProperties().get(SESSION_REUSE_ENABLED);
+        return configuredValue == null || Boolean.parseBoolean(configuredValue.toString());
     }
 
     private void configureSession() {

--- a/src/test/java/io/appform/dropwizard/sharding/dao/WrapperDaoTransactionReuseTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/WrapperDaoTransactionReuseTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class WrapperDaoTransactionReuseTest {
 
+    private static final String SESSION_REUSE_ENABLED = "db.sharding.transaction.session.reuse.enabled";
     private final List<SessionFactory> sessionFactories = new ArrayList<>();
     private WrapperDao<Order, OrderDao> dao;
 
@@ -223,6 +224,37 @@ class WrapperDaoTransactionReuseTest {
         assertNull(ver.get(Order.class, persisted2.getId()));
         ManagedSessionContext.unbind(sf);
         ver.close();
+    }
+
+    @Test
+    void testDisabledSessionReuseKeepsInnerDaoWorkAfterOuterRollback() {
+        String parentKey = "customer-no-reuse";
+        int shardId = dao.getShardCalculator().shardId(DBShardingBundleBase.DEFAULT_NAMESPACE, parentKey);
+        SessionFactory sf = sessionFactories.get(shardId);
+        sf.getProperties().put(SESSION_REUSE_ENABLED, false);
+
+        Session outer = sf.openSession();
+        ManagedSessionContext.bind(outer);
+        Transaction outerTxn = outer.beginTransaction();
+
+        Order order = Order.builder().customerId(parentKey).build();
+        order.setItems(List.of(OrderItem.builder().order(order).name("standalone-inner-write").build()));
+        Order persisted = dao.forParent(parentKey).save(order);
+        assertTrue(persisted.getId() > 0);
+
+        outerTxn.rollback();
+        assertEquals(TransactionStatus.ROLLED_BACK, outerTxn.getStatus());
+        if (ManagedSessionContext.hasBind(sf)) {
+            ManagedSessionContext.unbind(sf);
+        }
+        outer.close();
+
+        Session verificationSession = sf.openSession();
+        ManagedSessionContext.bind(verificationSession);
+        assertNotNull(verificationSession.get(Order.class, persisted.getId()),
+                "Inner DAO work should commit independently when session reuse is disabled");
+        ManagedSessionContext.unbind(sf);
+        verificationSession.close();
     }
 
     @Test

--- a/src/test/java/io/appform/dropwizard/sharding/utils/TransactionHandlerTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/utils/TransactionHandlerTest.java
@@ -20,9 +20,12 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+
 class TransactionHandlerTest {
 
     private static final Logger log = LoggerFactory.getLogger(TransactionHandlerTest.class);
+    private static final String SESSION_REUSE_ENABLED = "db.sharding.transaction.session.reuse.enabled";
 
     private SessionFactory sessionFactory;
     private Session session;
@@ -33,6 +36,7 @@ class TransactionHandlerTest {
         session = mock(Session.class);
         when(sessionFactory.openSession()).thenReturn(session);
         when(sessionFactory.getCurrentSession()).thenReturn(session); // Mock current session retrieval
+        when(sessionFactory.getProperties()).thenReturn(new HashMap<>());
     }
 
     @Test
@@ -99,6 +103,37 @@ class TransactionHandlerTest {
             fail("Unexpected exception: " + e.getMessage()); // Fail the test if any exception occurs
         } finally {
             // Unbind the session to clean up after the test
+            ManagedSessionContext.unbind(sessionFactory);
+        }
+    }
+
+    @Test
+    void testDoesNotReuseExistingSessionWhenSessionReuseIsDisabled() {
+        Session existingSession = mock(Session.class);
+        Session openedSession = mock(Session.class);
+        org.hibernate.Transaction existingTransaction = mock(org.hibernate.Transaction.class);
+        org.hibernate.Transaction newTransaction = mock(org.hibernate.Transaction.class);
+        HashMap<String, Object> properties = new HashMap<>();
+        properties.put(SESSION_REUSE_ENABLED, false);
+
+        when(sessionFactory.getProperties()).thenReturn(properties);
+        when(sessionFactory.openSession()).thenReturn(openedSession);
+        when(sessionFactory.getCurrentSession()).thenReturn(existingSession);
+        when(existingSession.getSessionFactory()).thenReturn(sessionFactory);
+        when(existingSession.getTransaction()).thenReturn(existingTransaction);
+        when(existingTransaction.isActive()).thenReturn(true);
+        when(openedSession.getTransaction()).thenReturn(newTransaction);
+        when(newTransaction.getStatus()).thenReturn(org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE);
+
+        ManagedSessionContext.bind(existingSession);
+        try {
+            TransactionHandler transactionHandler = new TransactionHandler(sessionFactory, false);
+            transactionHandler.beforeStart();
+
+            assertSame(openedSession, transactionHandler.getSession(),
+                    "A fresh session should be opened when session reuse is disabled");
+            verify(sessionFactory, times(1)).openSession();
+        } finally {
             ManagedSessionContext.unbind(sessionFactory);
         }
     }


### PR DESCRIPTION
## Summary
 - add config to control session reuse
 - keep reuse enabled by default
 - allow disabling per tenant / SessionFactory
 - add unit and integration coverage

## Context
PR #135 introduced automatic session reuse. This change keeps that behavior as the default, but adds a temporary compatibility switch for consumers that may still depend on the pre-PR #135 transaction/session model during migration. The intent is to support safe adoption of newer integration patterns without changing the long-term direction, after which this configurability can be removed.
