### PR TITLE
Add cross-DAO atomic locking to LockedContext

### DIFF
--- a/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LockedContext.java
@@ -153,6 +153,62 @@ public class LockedContext<T> {
     }
 
     /**
+     * Locks multiple rows of another {@link RelationalDao} entity using SELECT FOR UPDATE NOWAIT,
+     * applies a mutator to each, and persists the changes — all within the current transaction.
+     * <p>
+     * Each {@link DetachedCriteria} must match exactly one row (point lock, no gap locking).
+     * If any criteria matches no row or the NOWAIT lock fails, the entire transaction is rolled back.
+     *
+     * @param <U>          The type of the entity to be locked and mutated.
+     * @param relationalDao The DAO for the entity to lock.
+     * @param criteriaList  A list of criteria, each targeting one row.
+     * @param mutator       Applied to each locked entity; returns the mutated entity.
+     * @return This LockedContext for further chaining.
+     */
+    public <U> LockedContext<T> lockAndMutateEach(
+            RelationalDao<U> relationalDao,
+            List<DetachedCriteria> criteriaList,
+            UnaryOperator<U> mutator) {
+        return apply(parent -> {
+            try {
+                relationalDao.lockAndMutateEach(this, criteriaList, mutator);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    /**
+     * Locks a {@link LookupDao} entity by key using SELECT FOR UPDATE, applies a mutator,
+     * and persists the change — all within the current transaction.
+     * <p>
+     * The LookupDao entity must reside on the same shard as this LockedContext
+     * (e.g. both sharded on the same user ID).
+     *
+     * @param <U>     The type of the LookupDao entity.
+     * @param lookupDao The DAO for the entity to lock.
+     * @param key       The lookup key identifying the entity.
+     * @param mutator   Applied to the locked entity.
+     * @return This LockedContext for further chaining.
+     */
+    public <U> LockedContext<T> lockAndMutate(
+            LookupDao<U> lookupDao,
+            String key,
+            Mutator<U> mutator) {
+        return apply(parent -> {
+            try {
+                lookupDao.lockAndMutate(this, key, mutator);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    /**
      * Generates entity of type {@code U} using entityGenerator and then persists them
      *
      * @param <U>             The type of the associated entity to be saved.

--- a/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/LookupDao.java
@@ -224,6 +224,24 @@ public class LookupDao<T> implements ShardedDao<T> {
         return delegate.lockAndGetExecutor(dbNamespace, id);
     }
 
+    /**
+     * Locks an entity by its lookup key using SELECT FOR UPDATE, applies a mutator, and
+     * persists the change — all within the existing transaction of the provided {@link LockedContext}.
+     *
+     * @param <U>     The entity type of the parent LockedContext.
+     * @param context The LockedContext whose transaction is joined.
+     * @param key     The lookup key identifying the entity to lock.
+     * @param mutator The mutator to apply to the locked entity.
+     * @return The mutated entity.
+     * @throws javax.persistence.EntityNotFoundException if no entity is found for the given key.
+     */
+    public <U> T lockAndMutate(
+            final LockedContext<U> context,
+            final String key,
+            final LockedContext.Mutator<T> mutator) {
+        return delegate.lockAndMutate(context, key, mutator);
+    }
+
     public ReadOnlyContext<T> readOnlyExecutor(String id) {
         return readOnlyExecutor(id, x -> x);
     }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -68,6 +68,7 @@ import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.LockModeType;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Root;
@@ -442,6 +443,49 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         return new LockedContext<>(tenantId, shardId, dao.sessionFactory, () -> dao.getLockedForWrite(id),
                 DaoType.LOOKUP, entityClass, shardInfoProviders.get(tenantId), observer);
 
+    }
+
+    /**
+     * Locks an entity by its lookup key using SELECT FOR UPDATE, applies a mutator, and
+     * persists the change — all within the existing transaction of the provided {@link LockedContext}.
+     * <p>
+     * This is intended for cross-DAO chaining: e.g. locking a LookupDao entity inside a
+     * RelationalDao LockedContext when both reside on the same shard.
+     * <p>
+     * SINGLE-SHARD ONLY: the entity identified by {@code key} must map to the same shard as
+     * {@code context}. This is enforced: if {@code key} hashes to a different shard than
+     * {@code context.getShardId()}, an {@link IllegalArgumentException} is thrown before any lock
+     * is taken. Atomicity cannot be guaranteed across shards (separate databases, separate
+     * transactions), so cross-shard use is unsupported.
+     *
+     * @param <U>     The entity type of the parent LockedContext.
+     * @param context The LockedContext whose transaction is joined.
+     * @param key     The lookup key identifying the entity to lock.
+     * @param mutator The mutator to apply to the locked entity.
+     * @return The mutated entity.
+     * @throws IllegalArgumentException if {@code key} maps to a different shard than {@code context}.
+     * @throws javax.persistence.EntityNotFoundException if no entity is found for the given key.
+     */
+    <U> T lockAndMutate(
+            final LockedContext<U> context,
+            final String key,
+            final LockedContext.Mutator<T> mutator) {
+        val tenantId = context.getTenantId();
+        Preconditions.checkArgument(daos.containsKey(tenantId), "Unknown tenant: " + tenantId);
+        final int keyShardId = shardCalculator.shardId(tenantId, key);
+        Preconditions.checkArgument(keyShardId == context.getShardId(),
+                "Cross-shard lockAndMutate not allowed: key '%s' maps to shard %s but LockedContext "
+                        + "is on shard %s. The LookupDao entity must be co-sharded with the "
+                        + "LockedContext (e.g. keyed on the same userId).",
+                key, keyShardId, context.getShardId());
+        final LookupDaoPriv dao = daos.get(tenantId).get(context.getShardId());
+        final T entity = dao.getLockedForWrite(key);
+        if (entity == null) {
+            throw new EntityNotFoundException("Entity not found for key: " + key);
+        }
+        mutator.mutator(entity);
+        dao.update(entity);
+        return entity;
     }
 
     public ReadOnlyContext<T> readOnlyExecutor(String tenantId, String id) {

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -78,6 +78,7 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.query.Query;
 
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.Id;
 import javax.persistence.LockModeType;
 import javax.persistence.criteria.CriteriaBuilder;
@@ -86,6 +87,7 @@ import javax.persistence.criteria.Root;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -569,6 +571,53 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
         } catch (Exception e) {
             throw new RuntimeException("Error updating entity with scroll: " + querySpec, e);
         }
+    }
+
+    /**
+     * Locks multiple rows matching individual criteria using SELECT FOR UPDATE NOWAIT,
+     * applies a mutator to each, and persists the changes — all within the existing
+     * transaction of the provided {@link LockedContext}.
+     *
+     * <p>
+     * SINGLE-SHARD ONLY: every row addressed by {@code criteriaList} must reside on the same
+     * shard as {@code context} (the shard whose session/transaction is already bound). This
+     * feature exists to mutate co-sharded rows atomically; atomicity cannot be guaranteed across
+     * shards because each shard is a separate database with its own transaction. The caller is
+     * responsible for ensuring the criteria only match rows on {@code context.getShardId()}.
+     *
+     * @param <U>          The entity type of the parent LockedContext.
+     * @param context      The LockedContext whose transaction is joined.
+     * @param criteriaList A list of {@link DetachedCriteria}, each of which MUST match exactly one
+     *                     row (point lock by unique key). Zero rows throws (entity not found);
+     *                     more than one row throws {@code NonUniqueResultException}. Both roll back
+     *                     the entire transaction.
+     * @param mutator      A function applied to each locked entity; returns the mutated entity.
+     * @return The list of mutated entities in criteria order.
+     * @throws javax.persistence.EntityNotFoundException if any criteria matches no row
+     * @throws RuntimeException if the lock cannot be acquired (e.g. NOWAIT contention)
+     */
+    <U> List<T> lockAndMutateEach(
+            final LockedContext<U> context,
+            final List<DetachedCriteria> criteriaList,
+            final UnaryOperator<T> mutator) {
+        val tenantId = context.getTenantId();
+        Preconditions.checkArgument(daos.containsKey(tenantId), "Unknown tenant: " + tenantId);
+        Preconditions.checkArgument(criteriaList != null && !criteriaList.isEmpty(),
+                "criteriaList must not be null or empty");
+        final RelationalDaoPriv dao = daos.get(tenantId).get(context.getShardId());
+        final List<T> results = new ArrayList<>();
+        for (final DetachedCriteria criteria : criteriaList) {
+            // Each criteria must resolve to exactly one row: getLockedForWrite uses uniqueResult(),
+            // so >1 match throws NonUniqueResultException and rolls back the whole transaction.
+            final T entity = dao.getLockedForWrite(criteria);
+            if (entity == null) {
+                throw new EntityNotFoundException("Entity not found for criteria: " + criteria);
+            }
+            final T mutated = mutator.apply(entity);
+            dao.update(entity, mutated);
+            results.add(mutated);
+        }
+        return results;
     }
 
     <U> List<T> select(

--- a/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/RelationalDao.java
@@ -150,6 +150,26 @@ public class RelationalDao<T> implements ShardedDao<T> {
         delegate.save(context, entity, handler);
     }
 
+    /**
+     * Locks multiple rows matching individual criteria using SELECT FOR UPDATE NOWAIT,
+     * applies a mutator to each, and persists the changes — all within the existing
+     * transaction of the provided {@link LockedContext}.
+     *
+     * @param <U>          The entity type of the parent LockedContext.
+     * @param context      The LockedContext whose transaction is joined.
+     * @param criteriaList A list of {@link DetachedCriteria}, each expected to match exactly one row.
+     * @param mutator      A function applied to each locked entity; returns the mutated entity.
+     * @return The list of mutated entities in criteria order.
+     * @throws javax.persistence.EntityNotFoundException if any criteria matches no row
+     * @throws RuntimeException if the lock cannot be acquired (e.g. NOWAIT contention)
+     */
+    public <U> List<T> lockAndMutateEach(
+            final LockedContext<U> context,
+            final List<DetachedCriteria> criteriaList,
+            final UnaryOperator<T> mutator) {
+        return delegate.lockAndMutateEach(context, criteriaList, mutator);
+    }
+
 
     /**
      * Updates an entity within a locked context using a specific ID and an updater function.

--- a/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/dao/locktest/LockTest.java
@@ -51,6 +51,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -1370,6 +1375,405 @@ public class LockTest {
         assertEquals(p1.getMyId(), lookupDao.get("0").get().getMyId());
         assertEquals("Changed", lookupDao.get("0").get().getName());
         assertEquals("Changed", relationDao.get("0", 1L).get().getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    void testLockAndMutateEachUpdatesMultipleRelationalEntities() {
+        // Arrange
+        SomeLookupObject parent = SomeLookupObject.builder()
+                .myId("0")
+                .name("Parent")
+                .build();
+        lookupDao.save(parent);
+
+        SomeOtherObject c1 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0")
+                .value("OriginalOne")
+                .build()).get();
+        SomeOtherObject c2 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0")
+                .value("OriginalTwo")
+                .build()).get();
+
+        List<DetachedCriteria> criteriaList = List.of(
+                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c1.getId())),
+                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c2.getId()))
+        );
+
+        // Act: one transaction locks parent, locks+mutates c1 and c2
+        lookupDao.lockAndGetExecutor("0")
+                .lockAndMutateEach(relationDao, criteriaList, child -> {
+                    child.setValue("UPDATED");
+                    return child;
+                })
+                .mutate(p -> p.setName("Changed"))
+                .execute();
+
+        // Assert parent name was changed
+        assertEquals("Changed", lookupDao.get("0").get().getName());
+        // Assert both relational children were mutated
+        assertEquals("UPDATED", relationDao.get("0", c1.getId()).get().getValue());
+        assertEquals("UPDATED", relationDao.get("0", c2.getId()).get().getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testLockAndMutateEachThrowsWhenEntityNotFound() {
+        SomeLookupObject parent = SomeLookupObject.builder()
+                .myId("0")
+                .name("Parent")
+                .build();
+        lookupDao.save(parent);
+
+        // Criteria that matches no row
+        List<DetachedCriteria> criteriaList = List.of(
+                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", Long.MAX_VALUE))
+        );
+
+        assertThrows(RuntimeException.class, () ->
+                lookupDao.lockAndGetExecutor("0")
+                        .lockAndMutateEach(relationDao, criteriaList, child -> child)
+                        .execute()
+        );
+
+        // TX rolled back: parent name unchanged
+        assertEquals("Parent", lookupDao.get("0").get().getName());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testLockAndMutateUpdatesLookupEntityWithinRelationalContext() {
+        // Arrange: a lookup entity and a relational entity both on the shard for key "0"
+        SomeLookupObject parent = SomeLookupObject.builder()
+                .myId("0")
+                .name("InitialName")
+                .build();
+        lookupDao.save(parent);
+
+        SomeOtherObject relational = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0")
+                .value("InitialValue")
+                .build()).get();
+
+        // Act: lock relational entity; within the same TX also lock+mutate the lookup entity
+        relationDao.lockAndGetExecutor("0",
+                        DetachedCriteria.forClass(SomeOtherObject.class)
+                                .add(Restrictions.eq("id", relational.getId())))
+                .lockAndMutate(lookupDao, "0", lookup -> lookup.setName("UpdatedName"))
+                .mutate(r -> r.setValue("UpdatedValue"))
+                .execute();
+
+        // Assert relational entity value was changed
+        assertEquals("UpdatedValue", relationDao.get("0", relational.getId()).get().getValue());
+        // Assert lookup entity name was changed in the same transaction
+        assertEquals("UpdatedName", lookupDao.get("0").get().getName());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testLockAndMutateThrowsWhenLookupEntityNotFound() {
+        SomeLookupObject parent = SomeLookupObject.builder()
+                .myId("0")
+                .name("Parent")
+                .build();
+        lookupDao.save(parent);
+
+        SomeOtherObject relational = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0")
+                .value("Hello")
+                .build()).get();
+
+        // "nonexistent-key" has no SomeLookupObject → lockAndMutate throws RuntimeException
+        assertThrows(RuntimeException.class, () ->
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", relational.getId())))
+                        .lockAndMutate(lookupDao, "nonexistent-key",
+                                lookup -> lookup.setName("Updated"))
+                        .mutate(r -> r.setValue("ShouldNotPersist"))
+                        .execute()
+        );
+
+        // TX rolled back: relational entity value unchanged
+        assertEquals("Hello", relationDao.get("0", relational.getId()).get().getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testLockAndMutateThrowsWhenLookupKeyMapsToDifferentShard() {
+        // Anchor the LockedContext on shard for key "0" (maps to shard 0).
+        SomeLookupObject parentShard0 = SomeLookupObject.builder()
+                .myId("0")
+                .name("Shard0Parent")
+                .build();
+        lookupDao.save(parentShard0);
+
+        SomeOtherObject relational = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0")
+                .value("Hello")
+                .build()).get();
+
+        // A real lookup entity exists for key "1" — but "1" maps to shard 1, a DIFFERENT shard.
+        SomeLookupObject parentShard1 = SomeLookupObject.builder()
+                .myId("1")
+                .name("Shard1Parent")
+                .build();
+        lookupDao.save(parentShard1);
+
+        // Cross-shard lockAndMutate must be rejected with IllegalArgumentException,
+        // even though the entity exists (proves it's the shard guard, not "entity not found").
+        assertThrows(IllegalArgumentException.class, () ->
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", relational.getId())))
+                        .lockAndMutate(lookupDao, "1", lookup -> lookup.setName("ShouldNotPersist"))
+                        .mutate(r -> r.setValue("ShouldNotPersist"))
+                        .execute()
+        );
+
+        // TX rolled back: neither entity changed.
+        assertEquals("Hello", relationDao.get("0", relational.getId()).get().getValue());
+        assertEquals("Shard1Parent", lookupDao.get("1").get().getName());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testLockAndMutateEachProtectsEachRowFromConcurrentAccess() {
+        lookupDao.save(SomeLookupObject.builder().myId("0").name("Parent").build());
+
+        SomeOtherObject c1 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC1").build()).get();
+        SomeOtherObject c2 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC2").build()).get();
+
+        List<DetachedCriteria> criteriaList = List.of(
+                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c1.getId())),
+                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c2.getId()))
+        );
+
+        CountDownLatch bothRowsLockedLatch = new CountDownLatch(1);
+        CountDownLatch releaseLatch = new CountDownLatch(1);
+        AtomicBoolean firstMutatorCalled = new AtomicBoolean(false);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        // T1: locks c1, then c2 via lockAndMutateEach; signals only after c2 is locked
+        Future<?> txn1 = executor.submit(() -> {
+            try {
+                lookupDao.lockAndGetExecutor("0")
+                        .lockAndMutateEach(relationDao, criteriaList, child -> {
+                            if (firstMutatorCalled.getAndSet(true)) {
+                                // Second call: c2 is now locked — signal and hold
+                                bothRowsLockedLatch.countDown();
+                                try {
+                                    releaseLatch.await(5, TimeUnit.SECONDS);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            }
+                            child.setValue("T1_UPDATED");
+                            return child;
+                        })
+                        .execute();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        // Wait until T1 holds locks on both c1 and c2
+        assertTrue(bothRowsLockedLatch.await(5, TimeUnit.SECONDS), "T1 should lock both rows within 5s");
+
+        // T2: independently lock c2 directly (bypasses parent — tests row-level lock specifically)
+        assertThrows(RuntimeException.class, () ->
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", c2.getId())))
+                        .execute()
+        );
+
+        releaseLatch.countDown();
+        txn1.get(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals("T1_UPDATED", relationDao.get("0", c1.getId()).get().getValue());
+        assertEquals("T1_UPDATED", relationDao.get("0", c2.getId()).get().getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testLockAndMutateEachFailsWhenRowAlreadyLockedByAnotherTransaction() {
+        lookupDao.save(SomeLookupObject.builder().myId("0").name("Parent").build());
+
+        SomeOtherObject c1 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC1").build()).get();
+        SomeOtherObject c2 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC2").build()).get();
+
+        CountDownLatch c1LockedLatch = new CountDownLatch(1);
+        CountDownLatch releaseLatch = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        // T1: lock c1 directly via the traditional lockAndGetExecutor (single-row lock)
+        // Parent (SomeLookupObject) is NOT locked by T1.
+        Future<?> txn1 = executor.submit(() -> {
+            try {
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", c1.getId())))
+                        .mutate(child -> {
+                            c1LockedLatch.countDown();
+                            try {
+                                releaseLatch.await(5, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            child.setValue("T1_UPDATED");
+                        })
+                        .execute();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertTrue(c1LockedLatch.await(5, TimeUnit.SECONDS), "T1 should lock c1 within 5s");
+
+        // T2: lockAndMutateEach on [c1, c2] — parent lock succeeds (T1 doesn't hold it),
+        // but the NOWAIT lock on c1 fails immediately because T1 holds it.
+        assertThrows(RuntimeException.class, () ->
+                lookupDao.lockAndGetExecutor("0")
+                        .lockAndMutateEach(relationDao, List.of(
+                                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c1.getId())),
+                                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c2.getId()))
+                        ), child -> child)
+                        .execute()
+        );
+
+        releaseLatch.countDown();
+        txn1.get(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals("T1_UPDATED", relationDao.get("0", c1.getId()).get().getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testSingleTableLockAndMutateEachProtectsRowsFromConcurrentAccess() {
+        // Single-table scenario (analogous to user_balances sharded by user_id):
+        // c0 = anchor row, c1 + c2 = "program balance" rows — all in some_other_data, no SomeLookupObject needed.
+        SomeOtherObject c0 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("Anchor").build()).get();
+        SomeOtherObject c1 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC1").build()).get();
+        SomeOtherObject c2 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC2").build()).get();
+
+        CountDownLatch bothRowsLockedLatch = new CountDownLatch(1);
+        CountDownLatch releaseLatch = new CountDownLatch(1);
+        AtomicBoolean firstMutatorCalled = new AtomicBoolean(false);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        // T1: lock c0 as anchor, then lock c1 and c2 via lockAndMutateEach — all one table
+        Future<?> txn1 = executor.submit(() -> {
+            try {
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", c0.getId())))
+                        .lockAndMutateEach(relationDao, List.of(
+                                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c1.getId())),
+                                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c2.getId()))
+                        ), child -> {
+                            if (firstMutatorCalled.getAndSet(true)) {
+                                // Second call: c2 now locked — signal and hold
+                                bothRowsLockedLatch.countDown();
+                                try {
+                                    releaseLatch.await(5, TimeUnit.SECONDS);
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
+                            }
+                            child.setValue("T1_UPDATED");
+                            return child;
+                        })
+                        .execute();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertTrue(bothRowsLockedLatch.await(5, TimeUnit.SECONDS), "T1 should lock both rows within 5s");
+
+        // T2: independently try to lock c2 directly — same table, no parent involved
+        assertThrows(RuntimeException.class, () ->
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", c2.getId())))
+                        .execute()
+        );
+
+        releaseLatch.countDown();
+        txn1.get(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals("T1_UPDATED", relationDao.get("0", c1.getId()).get().getValue());
+        assertEquals("T1_UPDATED", relationDao.get("0", c2.getId()).get().getValue());
+    }
+
+    @Test
+    @SneakyThrows
+    public void testSingleTableLockAndMutateEachFailsWhenRowAlreadyLocked() {
+        // Reverse: T1 holds c1 via the traditional lockAndGetExecutor (single-row lock).
+        // T2 starts a lockAndMutateEach on [c1, c2] anchored at c0 — fails on c1.
+        SomeOtherObject c0 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("Anchor").build()).get();
+        SomeOtherObject c1 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC1").build()).get();
+        SomeOtherObject c2 = relationDao.save("0", SomeOtherObject.builder()
+                .myId("0").value("OriginalC2").build()).get();
+
+        CountDownLatch c1LockedLatch = new CountDownLatch(1);
+        CountDownLatch releaseLatch = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        // T1: lock c1 via traditional lockAndGetExecutor — does NOT lock c0 or c2
+        Future<?> txn1 = executor.submit(() -> {
+            try {
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", c1.getId())))
+                        .mutate(child -> {
+                            c1LockedLatch.countDown();
+                            try {
+                                releaseLatch.await(5, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                            child.setValue("T1_UPDATED");
+                        })
+                        .execute();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertTrue(c1LockedLatch.await(5, TimeUnit.SECONDS), "T1 should lock c1 within 5s");
+
+        // T2: anchor at c0 (unlocked), then lockAndMutateEach [c1, c2] — fails on c1
+        assertThrows(RuntimeException.class, () ->
+                relationDao.lockAndGetExecutor("0",
+                                DetachedCriteria.forClass(SomeOtherObject.class)
+                                        .add(Restrictions.eq("id", c0.getId())))
+                        .lockAndMutateEach(relationDao, List.of(
+                                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c1.getId())),
+                                DetachedCriteria.forClass(SomeOtherObject.class).add(Restrictions.eq("id", c2.getId()))
+                        ), child -> child)
+                        .execute()
+        );
+
+        releaseLatch.countDown();
+        txn1.get(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals("T1_UPDATED", relationDao.get("0", c1.getId()).get().getValue());
     }
 
     private boolean saveEntity(LockedContext<SomeLookupObject> lockedContext) {


### PR DESCRIPTION
## Cross-DAO Atomic Locking in `LockedContext`

### Summary

Adds two chaining methods to `LockedContext` that lock and mutate rows of **other** DAOs within the context's existing transaction. This makes it possible to lock and update **multiple rows across multiple tables atomically** — a single commit, a single rollback — as long as all rows reside on the **same shard**.

- **`lockAndMutateEach`** — lock N rows of a `RelationalDao` (each via `SELECT FOR UPDATE NOWAIT`)
- **`lockAndMutate`** — lock a `LookupDao` entity by key (via `SELECT FOR UPDATE` / `PESSIMISTIC_WRITE`)

Both join the transaction already opened by the `LockedContext`, so they participate in the same commit/rollback as the entry-point entity and any chained `mutate` / `save` calls.

---

### Motivation

The existing `LockedContext` API locks only the **entry-point** entity. Any other row a transaction needs to mutate — whether additional rows of the same table or rows of a different DAO — was read/updated **without a lock**, leaving a window for a concurrent transaction to mutate the same row (lost update).

A representative case: an operation that must lock several rows of a sharded table and one related lookup entity, then write additional related rows — all atomically. Concretely:

1. Lock several rows of a `RelationalDao` (updating a field on each)
2. Lock and update a `LookupDao` entity on the same shard
3. Save one or more related rows

Without a shared lock point across these, two concurrent operations on overlapping rows could interleave. The fix is to take `SELECT FOR UPDATE` on **every** row the transaction will mutate (not just the first), so concurrent transactions touching the same rows fail fast instead of racing.

---

### What's added

#### 1. `lockAndMutateEach` — lock multiple `RelationalDao` rows

```java
public <U> LockedContext<T> lockAndMutateEach(
        RelationalDao<U> relationalDao,
        List<DetachedCriteria> criteriaList,
        UnaryOperator<U> mutator)
```

- Each `DetachedCriteria` must match **exactly one row** (point lock by unique key — no gap locking). Zero matches → not-found exception; more than one → `NonUniqueResultException`. Either rolls back the whole transaction.
- Uses `LockMode.UPGRADE_NOWAIT` — fails immediately on contention (no blocking, no deadlocks).
- A single `UnaryOperator<U>` is applied once per locked row; each invocation returns the entity to persist.

#### 2. `lockAndMutate` — lock a `LookupDao` entity

```java
public <U> LockedContext<T> lockAndMutate(
        LookupDao<U> lookupDao,
        String key,
        Mutator<U> mutator)
```

- Uses `PESSIMISTIC_WRITE` on the keyed entity.
- Mutator is applied in place; the entity is updated in the same session.

#### Combined usage

```java
// All entities below are sharded on the same key, so they share one transaction.
parentDao.lockAndGetExecutor(shardKey, firstCriteria)          // opens txn, locks first row
    .filter(row -> row.isAvailable(), NOT_AVAILABLE)
    .mutate(row -> row.setFlag(true))
    .lockAndMutateEach(parentDao, remainingCriteria, row -> {   // lock additional rows of same table
        row.setFlag(true);
        return row;
    })
    .lockAndMutate(otherLookupDao, lookupKey, entity -> {       // lock a LookupDao entity (same shard)
        entity.setCounter(entity.getCounter() + 1);
    })
    .save(childDaoA, parent -> buildChildA(parent))
    .save(childDaoB, parent -> buildChildB(parent))
    .execute();   // single COMMIT — all locks released together
```

---

### Lock-mode semantics

The lock modes match each DAO's existing `getLockedForWrite` behavior — no new locking semantics are introduced:

| DAO | Method | Lock mode | Contention behavior |
|-----|--------|-----------|---------------------|
| `RelationalDao` | `getLockedForWrite(DetachedCriteria)` | `UPGRADE_NOWAIT` | fails immediately |
| `LookupDao` | `getLockedForWrite(key)` | `PESSIMISTIC_WRITE` | waits for lock |

---

### Constraints & guards

- **Same-shard only.** All locked rows must map to the **same shard** as the `LockedContext`. Cross-shard locking cannot be atomic (separate databases, separate transactions). For `lockAndMutate`, this is **enforced**: if the key hashes to a different shard than the context, an `IllegalArgumentException` is thrown **before any lock is taken** (rather than silently querying the wrong shard and reporting a misleading "entity not found"). For `lockAndMutateEach`, rows are addressed by arbitrary criteria with no shard key to hash, so co-sharding remains a documented caller contract.
- **Exactly one row per criteria** in `lockAndMutateEach` (see above).
- **Input validation**: unknown tenant and null/empty criteria list are rejected with clear errors.
- **No API or behavior changes** to existing methods, and no changes to transaction machinery, `OpType`, `OpContext`, or related types. The change is purely additive.

---

### Tests

8 new cases in `LockTest`:

| Test | Verifies |
|------|----------|
| `testLockAndMutateEachUpdatesMultipleRelationalEntities` | Happy path: multiple relational rows updated atomically |
| `testLockAndMutateEachThrowsWhenEntityNotFound` | Missing row → exception → rollback |
| `testLockAndMutateUpdatesLookupEntityWithinRelationalContext` | Happy path: LookupDao entity locked + mutated in same txn |
| `testLockAndMutateThrowsWhenLookupEntityNotFound` | Missing lookup entity → exception → rollback |
| `testLockAndMutateThrowsWhenLookupKeyMapsToDifferentShard` | Cross-shard key rejected with `IllegalArgumentException`; rollback |
| `testLockAndMutateEachProtectsEachRowFromConcurrentAccess` | T1 holds locks on two rows; T2 fails immediately (NOWAIT) |
| `testLockAndMutateEachFailsWhenRowAlreadyLockedByAnotherTransaction` | Pre-existing row lock blocks `lockAndMutateEach` |
| `testSingleTableLockAndMutateEachProtectsRowsFromConcurrentAccess` / `...FailsWhenRowAlreadyLocked` | Same guarantees in the single-table scenario |

All `LockTest` cases pass against the current `master`.
