### PR TITLE
fix: roll back implicit read transaction on the onError() path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.12-7</version>
+    <version>2.1.12-8</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>

--- a/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
+++ b/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
@@ -115,12 +115,7 @@ public class TransactionHandler {
             throw e;
         } finally {
             if (sessionAcquired) {
-                if (skipCommit && readOnly) {
-                    // isTransactionOptional=true reads skip beginTransaction(), so no Hibernate-managed
-                    // transaction exists. But autoCommit=false means an implicit DB transaction is open.
-                    // Roll it back directly to prevent MVCC snapshot leakage across pool connections.
-                    session.doWork(conn -> conn.rollback());
-                }
+                rollbackImplicitTransactionIfNeeded();
                 session.close();
                 ManagedSessionContext.unbind(sessionFactory);
                 MDC.remove(TENANT_ID);
@@ -138,10 +133,29 @@ public class TransactionHandler {
             }
         } finally {
             if (sessionAcquired) {
+                rollbackImplicitTransactionIfNeeded();
                 session.close();
                 ManagedSessionContext.unbind(sessionFactory);
                 MDC.remove(TENANT_ID);
             }
+        }
+    }
+
+    /**
+     * Rolls back the implicit database transaction opened by transaction-optional (read-only)
+     * operations before the owning session is closed and its connection returned to the pool.
+     * <p>
+     * When {@code isTransactionOptional=true}, {@link #beforeStart()} skips
+     * {@link #beginTransaction()}, so no Hibernate-managed transaction exists. However, pooled
+     * connections run with {@code autoCommit=false}, so the first SELECT silently opens an implicit
+     * DB transaction. If the connection is returned to the pool without a rollback, its
+     * REPEATABLE_READ MVCC snapshot stays pinned and a later borrower of the same physical
+     * connection can observe stale data. This must run on both the normal ({@link #afterEnd()})
+     * and error ({@link #onError()}) completion paths.
+     */
+    private void rollbackImplicitTransactionIfNeeded() {
+        if (skipCommit && readOnly) {
+            session.doWork(conn -> conn.rollback());
         }
     }
 

--- a/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
+++ b/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
@@ -72,6 +72,10 @@ public class TransactionHandler {
      * session is successfully set up. In case of any setup failure, it also ensures proper cleanup.
      *
      */
+    // Intentionally catches Throwable (not Exception): the acquired session/connection must be
+    // released even if setup fails with an Error (e.g. OOM during beginTransaction()), otherwise
+    // the pooled connection leaks. The Throwable is always rethrown, so no error is swallowed.
+    @SuppressWarnings("java:S1181")
     public void beforeStart() {
         try {
             if (ManagedSessionContext.hasBind(sessionFactory)) {

--- a/src/test/java/io/appform/dropwizard/sharding/BundleMvccSnapshotTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/BundleMvccSnapshotTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -146,6 +147,55 @@ class BundleMvccSnapshotTest {
         assertTrue(v2.isPresent());
         assertEquals("version-2", v2.get().getText(),
                 "LookupDao.get() must see the committed update — not a stale MVCC snapshot");
+    }
+
+    /**
+     * Companion to {@link #get_afterCrossPoolUpdate_seesLatestCommit()} that exercises the
+     * <b>error</b> completion path ({@code TransactionHandler.onError()}) rather than the normal
+     * one ({@code afterEnd()}).
+     *
+     * <p>A transaction-optional read ({@code transactionOptional=true}, {@code readOnly=true})
+     * runs its SELECT — silently opening an implicit DB transaction on the pooled read connection
+     * — and then throws while applying the post-fetch handler. This drives
+     * {@code TransactionExecutor} into {@code onError()}, which (like {@code afterEnd()}) must roll
+     * back the implicit transaction before the connection is returned to the pool. Without the
+     * {@code onError()} rollback, the REPEATABLE_READ snapshot stays pinned on the reused physical
+     * connection and the next read returns stale {@code "version-1"}.
+     *
+     * <p>{@code GetByLookupKey.apply()} executes {@code getter.apply(...)} (the SELECT) <i>before</i>
+     * {@code afterGet.apply(...)} (the handler), so a throwing handler guarantees the implicit
+     * transaction is already open when the exception propagates.
+     */
+    @Test
+    void get_afterErrorInOptionalRead_seesLatestCommit() throws Exception {
+        // 1. Write "version-1"
+        writeLookupDao.save(TestEntity.builder()
+                .externalId("mvcc-err-1")
+                .text("version-1")
+                .build());
+
+        // 2. Optional read whose SELECT runs (opening implicit T1 on C_read) and then throws in the
+        //    post-fetch handler -> TransactionExecutor.onError(). The fix rolls T1 back here.
+        final java.util.function.Function<TestEntity, TestEntity> throwingHandler = entity -> {
+            throw new IllegalStateException("boom after select");
+        };
+        assertThrows(IllegalStateException.class, () ->
+                readLookupDao.get("mvcc-err-1", throwingHandler));
+
+        // 3. Update to "version-2" via writeBundle — commits on a separate connection
+        writeLookupDao.update("mvcc-err-1", entity -> {
+            entity.ifPresent(e -> e.setText("version-2"));
+            return entity.orElse(null);
+        });
+
+        // 4. Read again — same physical C_read is reused (pool_size=1)
+        //    WITH FIX:    onError rolled T1 back → new T2 at fresh snapshot → "version-2" ✓
+        //    WITHOUT FIX: T1 still open (REPEATABLE_READ snapshot S1) → stale "version-1" ✗
+        val v2 = readLookupDao.get("mvcc-err-1");
+        assertTrue(v2.isPresent());
+        assertEquals("version-2", v2.get().getText(),
+                "After an errored optional read, onError() must roll back the connection so later "
+                        + "reads see the latest commit — not a stale MVCC snapshot");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Transaction-optional reads (`isTransactionOptional=true`, `readOnly=true` — e.g. `get`, `select`, `count`, `exists`, `scatterGather`) skip `beginTransaction()`. With pooled connections running `autoCommit=false`, the **first `SELECT` silently opens an implicit DB transaction** on the connection.

`afterEnd()` already rolls this back before returning the connection to the pool, but **`onError()` did not**. When such a read threw *after* its `SELECT` had executed, the connection was returned to the pool with the implicit transaction still open, **pinning its `REPEATABLE_READ` MVCC snapshot**. A later borrower of the same physical connection then observed **stale data** even after another connection had committed fresh rows.

## Root cause

Because the read skips `beginTransaction()`, Hibernate holds **no managed transaction**, so `session.close()` does not clean up the JDBC-level transaction. The implicit transaction must be rolled back explicitly. `afterEnd()` did this; `onError()` was missing the symmetric call.

```
Optional read borrows conn C → SELECT opens implicit T1 (snapshot S1)
   → handler / mapping / timeout throws → onError()
   → session.close() WITHOUT rollback → C returned with T1 still open
Writer commits X on another connection
Next optional read reuses C (within validationInterval, before the pool's
   next SELECT 1 re-commits) → reads inside T1 → sees S1 → misses X (STALE)
```

Intermittent and load-/error-correlated, which is why it survived the earlier `afterEnd()`-only fix.

## Change

- Extracted the implicit-transaction rollback into `rollbackImplicitTransactionIfNeeded()`.
- Invoke it from **both** `afterEnd()` and `onError()`, so the implicit transaction is always released regardless of completion path.
- No behavior change on the happy path (pure refactor of existing `afterEnd()` logic + new call site in `onError()`).

## Tests

Added `BundleMvccSnapshotTest#get_afterErrorInOptionalRead_seesLatestCommit`:

- Drives a real two-pool bundle setup (`autoCommit=false`, `maxSize=1`, `REPEATABLE_READ`) exactly like production.
- An optional read runs its `SELECT` (opening the implicit txn) and then throws in the post-fetch handler → hits `onError()`.
- Asserts a subsequent read sees the latest commit.

**Verification**
- With the fix: `BundleMvccSnapshotTest` + `WrapperDaoTransactionReuseTest` all green (6 tests).
- Regression proof: with the `onError()` call removed, the new test fails exactly as expected — `expected: <version-2> but was: <version-1>` (the pinned stale snapshot).

## Impact / risk

- Affects only self-owned (`sessionAcquired`) transaction-optional read-only sessions on their **error** path; nested/reused sessions and write paths are unchanged.
- Adds at most one `ROLLBACK` on a connection that errored — negligible and only on the failure path.
