### PR TITLE
fix: enforce transaction ownership invariant for reads (2.1.12-9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.dropwizard.sharding</groupId>
     <artifactId>db-sharding-bundle</artifactId>
-    <version>2.1.12-8</version>
+    <version>2.1.12-9</version>
     <name>Dropwizard Database Sharding Bundle</name>
     <url>https://github.com/santanusinha/dropwizard-db-sharding-bundle</url>
     <description>Application layer database sharding over SQL dbs</description>

--- a/src/main/java/io/appform/dropwizard/sharding/config/ShardedHibernateFactory.java
+++ b/src/main/java/io/appform/dropwizard/sharding/config/ShardedHibernateFactory.java
@@ -34,7 +34,7 @@ import java.util.List;
  * {@summary Config for shards hibernate factory.
  * <ul>
  * <li>shards : This holds shards information.</li>
- * <li>shardingOptions : This can be used to set certain settings in db-bundle like skipTransactionOnRead etc.</li>
+ * <li>shardingOptions : This can be used to set certain settings in db-bundle.</li>
  * </ul>}
  */
 @Data

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantLookupDao.java
@@ -472,7 +472,6 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                 key -> dao.getLocked(key, criteriaUpdater, LockMode.NONE),
                 null,
                 id,
-                false,
                 shardInfoProviders.get(tenantId), entityClass, observer);
     }
 
@@ -509,7 +508,6 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                 key -> dao.getLocked(key, criteriaUpdater, LockMode.NONE),
                 entityPopulator,
                 id,
-                false,
                 shardInfoProviders.get(tenantId), entityClass, observer);
     }
 
@@ -1034,7 +1032,6 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         private final int shardId;
         private final SessionFactory sessionFactory;
         private final Supplier<Boolean> entityPopulator;
-        private final boolean skipTransaction;
         private final TransactionExecutionContext executionContext;
         private final TransactionObserver observer;
 
@@ -1045,7 +1042,6 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
                 Function<String, T> getter,
                 Supplier<Boolean> entityPopulator,
                 String key,
-                boolean skipTxn,
                 final ShardInfoProvider shardInfoProvider,
                 final Class<?> entityClass,
                 TransactionObserver observer) {
@@ -1053,7 +1049,6 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
             this.shardId = shardId;
             this.sessionFactory = sessionFactory;
             this.entityPopulator = entityPopulator;
-            this.skipTransaction = skipTxn;
             this.observer = observer;
             val shardName = shardInfoProvider.shardName(shardId);
             val opContext = ReadOnlyForLookupDao.<T>builder()
@@ -1464,8 +1459,7 @@ public class MultiTenantLookupDao<T> implements ShardedDao<T> {
         private T executeImpl() {
             return observer.execute(executionContext, () -> {
                 TransactionHandler transactionHandler = new TransactionHandler(sessionFactory,
-                        true,
-                        this.skipTransaction);
+                        true);
                 transactionHandler.beforeStart();
                 try {
                     val opContext = ((ReadOnlyForLookupDao<T>) executionContext.getOpContext());

--- a/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/MultiTenantRelationalDao.java
@@ -1607,7 +1607,6 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> Lists.newArrayList(dao.getLocked(key, criteriaUpdater, LockMode.NONE)),
                 entityPopulator,
-                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,
@@ -1656,7 +1655,6 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> dao.select(selectParam),
                 entityPopulator,
-                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,
@@ -1706,7 +1704,6 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 dao.sessionFactory,
                 () -> dao.select(selectParam),
                 entityPopulator,
-                false,
                 shardInfoProviders.get(tenantId),
                 DaoType.RELATIONAL,
                 entityClass,
@@ -1763,7 +1760,6 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
         private final int shardId;
         private final SessionFactory sessionFactory;
         private final Supplier<Boolean> entityPopulator;
-        private final boolean skipTransaction;
         private final TransactionExecutionContext executionContext;
         private final TransactionObserver observer;
 
@@ -1773,7 +1769,6 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
                 final SessionFactory sessionFactory,
                 final Supplier<List<T>> getter,
                 final Supplier<Boolean> entityPopulator,
-                final boolean skipTxn,
                 final ShardInfoProvider shardInfoProvider,
                 final DaoType daoType,
                 final Class<?> entityClass,
@@ -1783,7 +1778,6 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
             this.shardId = shardId;
             this.sessionFactory = sessionFactory;
             this.entityPopulator = entityPopulator;
-            this.skipTransaction = skipTxn;
             this.observer = observer;
             val shardName = shardInfoProvider.shardName(shardId);
             val opContext = ReadOnlyForRelationalDao.<T>builder()
@@ -1910,8 +1904,7 @@ public class MultiTenantRelationalDao<T> implements ShardedDao<T> {
          */
         private List<T> executeImpl() {
             return observer.execute(executionContext, () -> {
-                TransactionHandler transactionHandler = new TransactionHandler(sessionFactory, true,
-                        this.skipTransaction);
+                TransactionHandler transactionHandler = new TransactionHandler(sessionFactory, true);
                 transactionHandler.beforeStart();
                 try {
                     val opContext = ((ReadOnlyForRelationalDao<T>) executionContext.getOpContext());

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Count.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Count.java
@@ -27,11 +27,6 @@ public class Count extends OpContext<Long> {
   }
 
   @Override
-  public boolean isTransactionOptional() {
-    return true;
-  }
-
-  @Override
   public OpType getOpType() {
     return OpType.COUNT;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/CountByQuerySpec.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/CountByQuerySpec.java
@@ -27,11 +27,6 @@ public class CountByQuerySpec extends OpContext<Long> {
   }
 
   @Override
-  public boolean isTransactionOptional() {
-    return true;
-  }
-
-  @Override
   public OpType getOpType() {
     return OpType.COUNT_BY_QUERY_SPEC;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Get.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Get.java
@@ -32,11 +32,6 @@ public class Get<T, R> extends OpContext<R> {
   }
 
   @Override
-  public boolean isTransactionOptional() {
-    return true;
-  }
-
-  @Override
   public OpType getOpType() {
     return OpType.GET;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/OpContext.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/OpContext.java
@@ -23,10 +23,6 @@ import java.util.function.Function;
 public abstract class OpContext<T> implements Function<Session, T> {
   public abstract OpType getOpType();
 
-  public boolean isTransactionOptional() {
-    return false;
-  }
-
   public abstract <P> P visit(OpContextVisitor<P> visitor);
 
   public interface OpContextVisitor<P> {

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/Select.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/Select.java
@@ -34,11 +34,6 @@ public class Select<T, R> extends OpContext<R> {
   }
 
   @Override
-  public boolean isTransactionOptional() {
-    return true;
-  }
-
-  @Override
   public OpType getOpType() {
     return OpType.SELECT;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/GetByLookupKey.java
+++ b/src/main/java/io/appform/dropwizard/sharding/dao/operations/lookupdao/GetByLookupKey.java
@@ -33,11 +33,6 @@ public class GetByLookupKey<T, R> extends OpContext<R> {
   }
 
   @Override
-  public boolean isTransactionOptional() {
-    return true;
-  }
-
-  @Override
   public OpType getOpType() {
     return OpType.GET_BY_LOOKUP_KEY;
   }

--- a/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
+++ b/src/main/java/io/appform/dropwizard/sharding/execution/TransactionExecutor.java
@@ -67,8 +67,7 @@ public class TransactionExecutor {
             .opContext(opContext)
             .build();
         return observer.execute(context, () -> {
-            val transactionHandler = new TransactionHandler(sessionFactory, readOnly,
-                opContext.isTransactionOptional());
+            val transactionHandler = new TransactionHandler(sessionFactory, readOnly);
             if (completeTransaction) {
                 transactionHandler.beforeStart();
             }

--- a/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
+++ b/src/main/java/io/appform/dropwizard/sharding/utils/TransactionHandler.java
@@ -43,13 +43,8 @@ public class TransactionHandler {
     private boolean sessionAcquired = false;
 
     public TransactionHandler(SessionFactory sessionFactory, boolean readOnly) {
-        this(sessionFactory, readOnly, false);
-    }
-
-    public TransactionHandler(SessionFactory sessionFactory, boolean readOnly, boolean skipCommit) {
         this.sessionFactory = sessionFactory;
         this.readOnly = readOnly;
-        this.skipCommit = skipCommit;
     }
 
     /**
@@ -59,17 +54,25 @@ public class TransactionHandler {
      * for nested transactions. It first checks if a Hibernate {@link Session} is already bound
      * to the current thread using {@link ManagedSessionContext}.
      * <ul>
-     * <li><b>If a session exists:</b> It is reused. The handler checks if a transaction is
-     * already active and updates its internal state to skip the final commit, thereby "joining"
-     * the existing transaction.</li>
+     * <li><b>If a session exists:</b> It is reused. The handler joins the caller's transaction:
+     * if that transaction is already active it skips the final commit (the outer owner will
+     * complete it); otherwise it begins one on the shared session.</li>
      * <li><b>If no session exists:</b> A new session is opened, configured, and bound to the
      * context. This handler instance then takes "ownership" of the session by setting the
      * {@code sessionAcquired} flag, becoming responsible for its closure and transaction completion.
      * </li>
      * </ul>
      * <p>
-     * If this handler is determined to be the owner of the transaction, it begins one after the
-     * session is successfully set up. In case of any setup failure, it also ensures proper cleanup.
+     * <b>Ownership invariant:</b> a handler that owns the session ({@code sessionAcquired == true})
+     * ALWAYS runs its unit of work inside a real, managed transaction — even for reads. Pooled
+     * connections run with {@code autoCommit=false} ({@code CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT
+     * =true}), so the first statement always opens an implicit DB transaction. If we skipped
+     * {@link #beginTransaction()} for an owned read, that implicit transaction could be left open
+     * when the connection is returned to the pool; a later borrower of the same connection could
+     * then observe a stale REPEATABLE_READ snapshot. Beginning a transaction keeps the connection
+     * bound until commit/rollback runs on the SAME connection. {@code skipCommit} therefore only
+     * ever applies to the join path, where an outer transaction already owns the connection
+     * lifecycle.
      *
      */
     // Intentionally catches Throwable (not Exception): the acquired session/connection must be
@@ -81,8 +84,7 @@ public class TransactionHandler {
             if (ManagedSessionContext.hasBind(sessionFactory)) {
                 session = sessionFactory.getCurrentSession();
                 final var existingTransaction = session.getTransaction();
-                skipCommit = skipCommit
-                        || (existingTransaction != null && existingTransaction.isActive());
+                skipCommit = existingTransaction != null && existingTransaction.isActive();
             }
             else {
                 session = sessionFactory.openSession();
@@ -119,7 +121,6 @@ public class TransactionHandler {
             throw e;
         } finally {
             if (sessionAcquired) {
-                rollbackImplicitTransactionIfNeeded();
                 session.close();
                 ManagedSessionContext.unbind(sessionFactory);
                 MDC.remove(TENANT_ID);
@@ -137,29 +138,10 @@ public class TransactionHandler {
             }
         } finally {
             if (sessionAcquired) {
-                rollbackImplicitTransactionIfNeeded();
                 session.close();
                 ManagedSessionContext.unbind(sessionFactory);
                 MDC.remove(TENANT_ID);
             }
-        }
-    }
-
-    /**
-     * Rolls back the implicit database transaction opened by transaction-optional (read-only)
-     * operations before the owning session is closed and its connection returned to the pool.
-     * <p>
-     * When {@code isTransactionOptional=true}, {@link #beforeStart()} skips
-     * {@link #beginTransaction()}, so no Hibernate-managed transaction exists. However, pooled
-     * connections run with {@code autoCommit=false}, so the first SELECT silently opens an implicit
-     * DB transaction. If the connection is returned to the pool without a rollback, its
-     * REPEATABLE_READ MVCC snapshot stays pinned and a later borrower of the same physical
-     * connection can observe stale data. This must run on both the normal ({@link #afterEnd()})
-     * and error ({@link #onError()}) completion paths.
-     */
-    private void rollbackImplicitTransactionIfNeeded() {
-        if (skipCommit && readOnly) {
-            session.doWork(conn -> conn.rollback());
         }
     }
 

--- a/src/test/java/io/appform/dropwizard/sharding/BundleMvccSnapshotTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/BundleMvccSnapshotTest.java
@@ -35,12 +35,13 @@ import static org.mockito.Mockito.when;
  * Regression test for the MVCC stale-read bug, exercised through the full bundle stack.
  *
  * <h3>The problem</h3>
- * {@link LookupDao#get(String)} uses {@code transactionOptional=true}, which means
- * {@code TransactionHandler} never calls {@code beginTransaction()}. Production connection pools
- * set {@code autoCommit=false}, so the first SQL statement silently opens an implicit database
- * transaction. If no {@code conn.rollback()} is issued before the connection is returned to the
- * pool, a REPEATABLE_READ snapshot is pinned on the pooled connection. A subsequent read on that
- * same physical connection sees stale data even after another connection committed fresh rows.
+ * {@link LookupDao#get(String)} was historically {@code transactionOptional=true}, which meant
+ * {@code TransactionHandler} never called {@code beginTransaction()} for the read. Production
+ * connection pools set {@code autoCommit=false}, so the first SQL statement silently opens an
+ * implicit database transaction. If the implicit transaction is left open when the connection is
+ * returned to the pool, a REPEATABLE_READ snapshot is pinned on the pooled connection. A
+ * subsequent read on that same physical connection sees stale data even after another connection
+ * committed fresh rows.
  *
  * <h3>Setup</h3>
  * Two separate bundle instances both point to the same H2 named database:
@@ -52,10 +53,12 @@ import static org.mockito.Mockito.when;
  * </ul>
  *
  * <h3>How the fix is validated</h3>
- * {@code TransactionHandler.afterEnd()} calls {@code conn.rollback()} when
- * {@code skipCommit && readOnly && sessionAcquired}. This releases the REPEATABLE_READ snapshot
- * on the pooled read connection before it is returned. Without the fix, the second
- * {@code readLookupDao.get()} returns stale {@code "version-1"}.
+ * Under the ownership invariant, {@code TransactionHandler} ALWAYS begins a real managed
+ * transaction for an owned session — even a read-only one — and commits it in
+ * {@code afterEnd()} (or rolls it back in {@code onError()}) on the SAME connection before it is
+ * returned to the pool. This closes the implicit DB transaction and releases the REPEATABLE_READ
+ * snapshot on the pooled read connection. Without the fix (transaction-optional read, no
+ * begin/commit), the second {@code readLookupDao.get()} returns stale {@code "version-1"}.
  */
 class BundleMvccSnapshotTest {
 
@@ -109,13 +112,14 @@ class BundleMvccSnapshotTest {
      * Sequence:
      * <ol>
      *   <li>Write {@code "version-1"} via writeBundle (own Tomcat pool connection, commits).</li>
-     *   <li>Read via readBundle → {@code LookupDao → TransactionHandler(readSf, readOnly=true,
-     *       transactionOptional=true)}. Implicit T1 opens on the pooled read connection C_read.
-     *       The fix calls {@code conn.rollback()} → T1 released, C_read is clean.</li>
+     *   <li>Read via readBundle → {@code LookupDao → TransactionHandler(readSf, readOnly=true)}.
+     *       The owned session begins a real transaction; the SELECT runs inside it and
+     *       {@code afterEnd()} commits on the pooled read connection C_read, releasing any
+     *       snapshot. C_read is clean.</li>
      *   <li>Write {@code "version-2"} via writeBundle (commits on a separate connection).</li>
      *   <li>Read again via readBundle — the same physical connection C_read is reused:
      *       <ul>
-     *         <li><b>With fix:</b> T1 was rolled back → new T2 at fresh snapshot → {@code "version-2"} ✓</li>
+     *         <li><b>With fix:</b> T1 committed → new T2 at fresh snapshot → {@code "version-2"} ✓</li>
      *         <li><b>Without fix:</b> T1 still open (REPEATABLE_READ snapshot S1) → stale
      *             {@code "version-1"} ✗</li>
      *       </ul></li>
@@ -129,7 +133,7 @@ class BundleMvccSnapshotTest {
                 .text("version-1")
                 .build());
 
-        // 2. Read via readBundle (transactionOptional=true) — fix calls conn.rollback() in afterEnd()
+        // 2. Read via readBundle — owned session begins+commits a real transaction in afterEnd()
         val v1 = readLookupDao.get("mvcc-1");
         assertTrue(v1.isPresent());
         assertEquals("version-1", v1.get().getText());
@@ -141,7 +145,7 @@ class BundleMvccSnapshotTest {
         });
 
         // 4. Read again — same physical C_read is reused (pool_size=1)
-        //    WITH FIX:    T1 rolled back → new T2 at fresh snapshot → "version-2" ✓
+        //    WITH FIX:    T1 committed → new T2 at fresh snapshot → "version-2" ✓
         //    WITHOUT FIX: T1 still open (REPEATABLE_READ snapshot S1) → stale "version-1" ✗
         val v2 = readLookupDao.get("mvcc-1");
         assertTrue(v2.isPresent());
@@ -154,13 +158,12 @@ class BundleMvccSnapshotTest {
      * <b>error</b> completion path ({@code TransactionHandler.onError()}) rather than the normal
      * one ({@code afterEnd()}).
      *
-     * <p>A transaction-optional read ({@code transactionOptional=true}, {@code readOnly=true})
-     * runs its SELECT — silently opening an implicit DB transaction on the pooled read connection
-     * — and then throws while applying the post-fetch handler. This drives
-     * {@code TransactionExecutor} into {@code onError()}, which (like {@code afterEnd()}) must roll
-     * back the implicit transaction before the connection is returned to the pool. Without the
-     * {@code onError()} rollback, the REPEATABLE_READ snapshot stays pinned on the reused physical
-     * connection and the next read returns stale {@code "version-1"}.
+     * <p>A transaction-optional-style read ({@code readOnly=true}) now runs inside a real
+     * transaction: its SELECT executes and then the post-fetch handler throws. This drives
+     * {@code TransactionExecutor} into {@code onError()}, which rolls the transaction back on the
+     * pooled read connection before it is returned. Without a transaction (the old
+     * transaction-optional path), the implicit REPEATABLE_READ snapshot would stay pinned on the
+     * reused physical connection and the next read would return stale {@code "version-1"}.
      *
      * <p>{@code GetByLookupKey.apply()} executes {@code getter.apply(...)} (the SELECT) <i>before</i>
      * {@code afterGet.apply(...)} (the handler), so a throwing handler guarantees the implicit
@@ -174,8 +177,8 @@ class BundleMvccSnapshotTest {
                 .text("version-1")
                 .build());
 
-        // 2. Optional read whose SELECT runs (opening implicit T1 on C_read) and then throws in the
-        //    post-fetch handler -> TransactionExecutor.onError(). The fix rolls T1 back here.
+        // 2. Optional-style read whose SELECT runs inside a real transaction and then throws in the
+        //    post-fetch handler -> TransactionExecutor.onError(). The fix rolls the txn back here.
         final java.util.function.Function<TestEntity, TestEntity> throwingHandler = entity -> {
             throw new IllegalStateException("boom after select");
         };
@@ -189,7 +192,7 @@ class BundleMvccSnapshotTest {
         });
 
         // 4. Read again — same physical C_read is reused (pool_size=1)
-        //    WITH FIX:    onError rolled T1 back → new T2 at fresh snapshot → "version-2" ✓
+        //    WITH FIX:    onError rolled the txn back → new T2 at fresh snapshot → "version-2" ✓
         //    WITHOUT FIX: T1 still open (REPEATABLE_READ snapshot S1) → stale "version-1" ✗
         val v2 = readLookupDao.get("mvcc-err-1");
         assertTrue(v2.isPresent());

--- a/src/test/java/io/appform/dropwizard/sharding/utils/TransactionHandlerTest.java
+++ b/src/test/java/io/appform/dropwizard/sharding/utils/TransactionHandlerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,11 +58,21 @@ class TransactionHandlerTest {
     }
 
     @Test
-    void testSkipCommit() {
-        TransactionHandler transactionHandler = new TransactionHandler(sessionFactory, false, true);
+    void testOwnedReadRunsInTransactionAndCommits() {
+        // Ownership invariant: even a read-only (transaction-optional) owned session must run
+        // inside a real managed transaction so the pooled connection is held until commit and the
+        // implicit REPEATABLE_READ DB transaction is closed on the SAME connection.
+        org.hibernate.Transaction transaction = mock(org.hibernate.Transaction.class);
+        when(session.getTransaction()).thenReturn(transaction);
+        when(transaction.getStatus()).thenReturn(org.hibernate.resource.transaction.spi.TransactionStatus.ACTIVE);
+
+        TransactionHandler transactionHandler = new TransactionHandler(sessionFactory, true);
         transactionHandler.beforeStart();
-        transactionHandler.afterEnd(); // Updated to use afterEnd for transaction completion
-        verify(session, never()).getTransaction();
+        transactionHandler.afterEnd();
+
+        verify(session, times(1)).beginTransaction(); // begin runs even for reads
+        verify(transaction, times(1)).commit();
+        verify(session, times(1)).close();
     }
 
     @Test


### PR DESCRIPTION
## Summary
Removes the **transaction-optional** concept and enforces an **ownership invariant** in `TransactionHandler`: a handler that owns its session ALWAYS runs its unit of work inside a real managed transaction — even a read-only one — so it begins and commits on the SAME pooled connection. This closes an implicit-transaction connection leak that caused intermittent stale reads under `REPEATABLE_READ`.

## Why (root cause)
With the pool at `autoCommit=false` and `hibernate.connection.provider_disables_autocommit=true`, a transaction-optional read skips `beginTransaction()`. The first `SELECT` opens an implicit DB transaction, and because no Hibernate transaction is active, the connection — with that transaction still open — is returned to the pool **immediately after the query**, not at session close. On a single-node **REPEATABLE_READ** (Galera) cluster the pinned MVCC snapshot then causes intermittent stale reads: a committed row read back as missing, which later self-heals.

The old `session.doWork(conn -> conn.rollback())` band-aid cannot fix this — by the time it runs, the leaky connection is already back in the pool, so `doWork` acquires a *different* connection and rolls back the wrong one, leaving the original pinned.

**Exact Hibernate path (identical in `5.6.15.Final` and `6.6.53.Final`):**
1. `org.hibernate.internal.SessionImpl#afterOperation(boolean)` — after each query: `if (!isTransactionInProgress()) getJdbcCoordinator().afterTransaction();`. With no active transaction, this fires.
2. `org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl#afterTransaction()` → `org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl#afterTransaction()` → `releaseConnection()`. The effective release mode is `AFTER_TRANSACTION` (`PhysicalConnectionHandlingMode.DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION`, resolved by `determineConnectionHandlingMode`). `releaseConnection()` sets `physicalConnection = null` and returns the connection — implicit txn still open — to the pool.
3. The band-aid's `session.doWork(...)` → `org.hibernate.internal.AbstractSharedSessionContract#doWork` → `JdbcCoordinatorImpl#coordinateWork` → `getLogicalConnection().getPhysicalConnection()` → `LogicalConnectionManagedImpl#acquireConnectionIfNeeded()` obtains a **fresh** pooled connection (since `physicalConnection == null`) and rolls *that* one back. The leaked connection is never touched.

**Correction vs. an earlier assumption:** this is **not** Hibernate-6-specific. The `SessionImpl.afterOperation` → `afterTransaction` → `releaseConnection` path and the `doWork` → `coordinateWork` re-acquisition are byte-for-byte identical in Hibernate 5.6.15 and 6.6.53, so the leak reproduces on **both** lines (confirmed empirically on H5 as well). The fix is release-mode-independent: an owned session always begins and commits a real transaction, closing the implicit transaction on the *same* held connection before it returns to the pool.

## Behavior change (please review carefully — stable line)
Every owned read now runs an explicit `begin`+`commit` instead of relying on Hibernate implicit connection handling. Cost is the same round-trip the connection lifecycle already required; read-only sessions skip flush so the COMMIT is clean. This is a semantics change on a widely-used released line — the full suite passes, but reviewers should sanity-check any callers that depended on the old no-transaction read behavior.

## Changes
- `TransactionHandler`: owned sessions always `begin`+`commit`; `skipCommit` only applies to the join path. Removed dead `rollbackImplicitTransactionIfNeeded()` and the unused 3-arg constructor.
- Deleted `isTransactionOptional()` from `OpContext` / `Select` / `Count` / `Get` / `CountByQuerySpec` / `GetByLookupKey`.
- Removed always-false `skipTransaction`/`skipTxn` dead code from `MultiTenant{Relational,Lookup}Dao` `ReadOnlyContext` (+ literal `false` call-site args; 3 sites in RelationalDao, 2 in LookupDao).
- `TransactionExecutor` uses the 2-arg `TransactionHandler` constructor.
- Cleaned a stale `skipTransactionOnRead` javadoc mention in `ShardedHibernateFactory`.
- Version `2.1.12-8` -> `2.1.12-9`.

## Tests
- `TransactionHandlerTest`: replaced the old skip-commit test with `testOwnedReadRunsInTransactionAndCommits`.
- `BundleMvccSnapshotTest`: cross-pool stale-read regression (H2, `pool_size=1`, `REPEATABLE_READ`, both `afterEnd` and `onError` paths) — docs updated to the invariant; assertions unchanged.
- Full bundle suite: **307 tests, 0 failures, 0 errors**.

## Companion
Hibernate 6 equivalent: #187 (`hibernate6-new`, `2.1.12-HIBERNATE6-RC7`).


---


## How it happened

### The connection leak

```mermaid
sequenceDiagram
    autonumber
    participant TH as TransactionHandler
    participant HS as Hibernate Session
    participant POOL as JDBC Pool
    participant DB as MariaDB

    Note over TH: transaction-optional read, beginTransaction skipped
    TH->>HS: open session
    HS->>POOL: borrow C1
    HS->>DB: SELECT on C1
    Note over DB: implicit txn T1 opens and pins a snapshot
    HS->>POOL: afterOperation releases C1 right after the SELECT
    Note over POOL,DB: C1 back in pool with T1 still open
    TH->>HS: afterEnd does a rollback via doWork
    HS->>POOL: coordinateWork acquires a different conn C2
    HS->>DB: rollback runs on C2, the wrong connection
    Note over POOL,DB: C1 stays leaked with T1 open
```

No Hibernate transaction is active, so `SessionImpl.afterOperation` releases C1 back to the pool right after the SELECT and the old rollback re-acquires a different connection. This path is identical in Hibernate 5 and 6, so the leak occurs on both.

### The stale read the leak causes

```mermaid
sequenceDiagram
    autonumber
    participant W as Writer
    participant DB as MariaDB
    participant R as Reader on leaked C1

    Note over R,DB: C1 holds an old snapshot from time t0
    W->>DB: INSERT workflow then COMMIT
    R->>DB: SELECT workflow on C1
    Note over R: sees nothing, workflow does not exist
    Note over R,DB: later the open txn closes and it self heals
```

### The fix

```mermaid
sequenceDiagram
    autonumber
    participant TH as TransactionHandler
    participant HS as Hibernate Session
    participant POOL as JDBC Pool
    participant DB as MariaDB

    Note over TH: owned read, beginTransaction now runs
    TH->>HS: open session and begin txn
    HS->>POOL: borrow C1
    HS->>DB: SELECT on C1
    Note over HS,POOL: txn active so C1 is held, not released
    TH->>HS: afterEnd commits
    HS->>DB: COMMIT on the same C1
    Note over DB: implicit txn closed and snapshot released
    HS->>POOL: C1 returned clean
```

An owned session always begins a transaction, so `isTransactionInProgress()` is true and C1 stays bound until `afterEnd` commits on that same C1 regardless of release mode.

